### PR TITLE
Fixing lint errors, adding lint check to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,16 @@ jobs:
       with:
         go-version: '1.21'
 
+    - name: Install lint deps
+      shell: bash --noprofile --norc -x -eo pipefail {0}
+      run: |
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
+
+    - name: Run Lint
+      shell: bash --noprofile --norc -x -eo pipefail {0}
+      run: |
+        golangci-lint run
+
     - name: Build nex-node
       working-directory: ./nex-node/cmd/nex-node
       run: go build -tags netgo -ldflags '-extldflags "-static"'

--- a/agent-api/events.go
+++ b/agent-api/events.go
@@ -37,7 +37,7 @@ func NewAgentEvent(sourceId string, eventType string, event interface{}) cloudev
 	cloudevent.SetTime(time.Now().UTC())
 	cloudevent.SetType(eventType)
 	cloudevent.SetDataContentType(cloudevents.ApplicationJSON)
-	cloudevent.SetData(event)
+	_ = cloudevent.SetData(event)
 
 	return cloudevent
 }

--- a/control-api/client.go
+++ b/control-api/client.go
@@ -113,7 +113,10 @@ func (api *apiClient) ListNodes() ([]PingResponse, error) {
 	}
 	msg := nats.NewMsg(fmt.Sprintf("%s.PING", APIPrefix))
 	msg.Reply = sub.Subject
-	api.nc.PublishMsg(msg)
+	err = api.nc.PublishMsg(msg)
+	if err != nil {
+		return nil, err
+	}
 
 	<-ctx.Done()
 	return responses, nil

--- a/control-api/run_test.go
+++ b/control-api/run_test.go
@@ -27,12 +27,15 @@ func TestEncryption(t *testing.T) {
 		TargetPublicXKey(recipientPk),
 	)
 
-	request.DecryptRequestEnvironment(recipientKey)
+	err := request.DecryptRequestEnvironment(recipientKey)
+	if err != nil {
+		t.Fatalf("Did not decrypt request environment: %s", err)
+	}
 	if request.WorkloadEnvironment["TOP_SECRET_LUGGAGE"] != "12345" {
 		t.Fatalf("Expected a good luggage password, found %s", request.WorkloadEnvironment["TOP_SECRET_LUGGAGE"])
 	}
 
-	_, err := request.Validate(recipientKey)
+	_, err = request.Validate(recipientKey)
 	if err != nil {
 		t.Fatalf("Expected no error, but got one: %s", err)
 	}

--- a/control-api/stop_test.go
+++ b/control-api/stop_test.go
@@ -28,7 +28,10 @@ func TestStopValidation(t *testing.T) {
 		TargetPublicXKey(recipientPk),
 	)
 
-	request.Validate(recipientKey) // need this to produce the `DecodedClaims` field
+	_, err := request.Validate(recipientKey) // need this to produce the `DecodedClaims` field
+	if err != nil {
+		t.Fatalf("Failed to validate request that should've passed: %s", err)
+	}
 
 	originalClaims := request.DecodedClaims
 	fmt.Printf("%+v", originalClaims)
@@ -36,7 +39,7 @@ func TestStopValidation(t *testing.T) {
 
 	stopRequest, _ := NewStopRequest("1234", "testworkload", "Nx", issuerAccount)
 
-	err := stopRequest.Validate(&originalClaims)
+	err = stopRequest.Validate(&originalClaims)
 	if err != nil {
 		t.Fatalf("Expected no errors during positive path validation, got %s", err)
 	}

--- a/nex-agent/nex-agent.go
+++ b/nex-agent/nex-agent.go
@@ -13,5 +13,8 @@ const (
 func HaltVM(err error) {
 	// On the off chance the agent's log is captured from the vm
 	fmt.Fprintf(os.Stderr, "Terminating Firecracker VM due to fatal error: %s\n", err)
-	syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART)
+	err = syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to reboot: %s", err)
+	}
 }

--- a/nex-cli/columns.go
+++ b/nex-cli/columns.go
@@ -11,7 +11,3 @@ func newColumns(heading string, a ...any) *columns.Writer {
 
 	return w
 }
-
-func f(v any) string {
-	return columns.F(v)
-}

--- a/nex-cli/nodes.go
+++ b/nex-cli/nodes.go
@@ -7,6 +7,7 @@ import (
 
 	controlapi "github.com/ConnectEverything/nex/control-api"
 	"github.com/choria-io/fisk"
+	"github.com/nats-io/natscli/columns"
 )
 
 // Uses a control API client to request a node list from a NATS environment
@@ -46,10 +47,13 @@ func NodeInfo(ctx *fisk.ParseContext) error {
 	return nil
 }
 
+func render(cols *columns.Writer) {
+	_ = cols.Frender(os.Stdout)
+}
 func renderNodeInfo(info *controlapi.InfoResponse, id string) {
 	cols := newColumns("NEX Node Information")
 
-	defer cols.Frender(os.Stdout)
+	defer render(cols)
 	cols.AddRow("Node", id)
 	cols.AddRowf("Xkey", info.PublicXKey)
 	cols.AddRow("Version", info.Version)
@@ -86,7 +90,6 @@ func renderNodeInfo(info *controlapi.InfoResponse, id string) {
 		}
 		cols.Indent(0)
 	}
-
 }
 
 func renderNodeList(nodes []controlapi.PingResponse) {

--- a/nex-cli/runner.go
+++ b/nex-cli/runner.go
@@ -27,6 +27,10 @@ func StopWorkload(ctx *fisk.ParseContext) error {
 		return err
 	}
 	stopRequest, err := controlapi.NewStopRequest(StopOpts.WorkloadId, StopOpts.WorkloadName, StopOpts.TargetNode, issuerKp)
+	if err != nil {
+		fmt.Printf("⛔ Failed to create workload request: %s\n", err)
+		return err
+	}
 	resp, err := nodeClient.StopWorkload(stopRequest)
 	if err != nil {
 		fmt.Printf("⛔ Workload stop request failed: %s\n", err)

--- a/nex-node/agentcomms.go
+++ b/nex-node/agentcomms.go
@@ -43,7 +43,7 @@ func handleAgentLog(mgr *MachineManager) func(m *nats.Msg) {
 			return
 		}
 
-		mgr.nc.Publish(logPublishSubject(vm.namespace, mgr.PublicKey(), vm.workloadSpecification.DecodedClaims.Subject, vmId), bytes)
+		_ = mgr.nc.Publish(logPublishSubject(vm.namespace, mgr.PublicKey(), vm.workloadSpecification.DecodedClaims.Subject, vmId), bytes)
 
 	}
 }

--- a/nex-node/machine_mgr.go
+++ b/nex-node/machine_mgr.go
@@ -140,7 +140,7 @@ func (m *MachineManager) Stop() error {
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	m.nc.Drain()
+	_ = m.nc.Drain()
 
 	return nil
 }


### PR DESCRIPTION
IMHO there are a number of spots where making the linter happy re: error checking makes the resulting Go code uglier, but I do want to have a linter run for the builds. Maybe we can either clean up the code or clean up the linting rules later.