### PR TITLE
carries tags from node configs. allows workload type limits

### DIFF
--- a/control-api/types.go
+++ b/control-api/types.go
@@ -30,8 +30,8 @@ type PingResponse struct {
 	NodeId          string            `json:"node_id"`
 	Version         string            `json:"version"`
 	Uptime          string            `json:"uptime"`
-	RunningMachines int               `json:"running_machines"`
 	Tags            map[string]string `json:"tags,omitempty"`
+	RunningMachines int               `json:"running_machines"`
 }
 
 type MemoryStat struct {
@@ -41,12 +41,13 @@ type MemoryStat struct {
 }
 
 type InfoResponse struct {
-	Version    string            `json:"version"`
-	Uptime     string            `json:"uptime"`
-	PublicXKey string            `json:"public_xkey"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Memory     *MemoryStat       `json:"memory,omitempty"`
-	Machines   []MachineSummary  `json:"machines"`
+	Version                string            `json:"version"`
+	Uptime                 string            `json:"uptime"`
+	PublicXKey             string            `json:"public_xkey"`
+	Tags                   map[string]string `json:"tags,omitempty"`
+	Memory                 *MemoryStat       `json:"memory,omitempty"`
+	Machines               []MachineSummary  `json:"machines"`
+	SupportedWorkloadTypes []string          `json:"supported_workload_types,omitempty"`
 }
 
 type MachineSummary struct {

--- a/examples/nodeconfigs/simple.json
+++ b/examples/nodeconfigs/simple.json
@@ -9,5 +9,8 @@
     "machine_template": {
         "vcpu_count": 1,
         "memsize_mib": 256
+    },
+    "tags": {
+        "simple": "true"
     }
 }

--- a/nex-node/cmd/nex-node/main.go
+++ b/nex-node/cmd/nex-node/main.go
@@ -108,7 +108,7 @@ func cmdUp(opts *nexnode.CliOptions, ctx context.Context, cancel context.CancelF
 
 	setupSignalHandlers(log, manager)
 
-	api := nexnode.NewApiListener(log, manager, make(map[string]string))
+	api := nexnode.NewApiListener(log, manager, config)
 	err = api.Start()
 	if err != nil {
 		log.WithError(err).Error("Failed to start API listener")


### PR DESCRIPTION
1. makes the tags support actually work (it was faked before)
2. makes it so we can explicitly set the supported workload types for a given node, the default does not include oci (e.g. OCI needs to be opt-in because of the bloat)