### PR TITLE
Fixes #21

### DIFF
--- a/nex-cli/devrunner.go
+++ b/nex-cli/devrunner.go
@@ -156,10 +156,7 @@ func uploadWorkload(nc *nats.Conn, filename string) (string, string, error) {
 func readOrGenerateIssuer() (nkeys.KeyPair, error) {
 	filename := path.Join(nexDir, "issuer.nk")
 	bytes, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	if len(bytes) == 0 {
+	if errors.Is(err, fs.ErrNotExist) {
 		return writeNewIssuer()
 	} else {
 		fmt.Printf("Reusing existing issuer account key: %s\n", filename)


### PR DESCRIPTION
Fixes #21, making it safe to to devrun without any pre-existing files in `~/.nex`