### PR TITLE
Run pnpm install to ensure node_modules/ exists in ui

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,6 +34,7 @@ tasks:
     dir: ui/web
     cmds:
       - curl -fsSL https://get.pnpm.io/install.sh | sh -
+      - pnpm install
       - pnpm build
 
   build:


### PR DESCRIPTION
This PR fixes `task build`, which would fail in the event `ui/web/node_modules` didn't exist.