### PR TITLE
feat: search PATH for CNI plugins and required binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ dist/
 # nex binaries
 nex/nex
 rootfs.ext4
+
+.idea

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,7 +51,7 @@ tasks:
     deps: [clean, agent]
     cmds:
       - sudo go run github.com/onsi/ginkgo/v2/ginkgo -r --randomize-all --randomize-suites --vv --trace --keep-going ./spec #--cover --coverprofile=.coverage-report.out
-      - go test -v -race ./test
+      - go test -tags netgo -ldflags '-extldflags "-static"'-v -race ./test
 
   ui:
     dir: ui/web

--- a/internal/node/config.go
+++ b/internal/node/config.go
@@ -19,11 +19,15 @@ const defaultNodeVcpuCount = 1
 var (
 	// docker/OCI needs to be explicitly enabled in node configuration
 	defaultWorkloadTypes = []string{"elf", "v8", "wasm"}
+	defaultBinPath       = append([]string{"/usr/local/bin"}, filepath.SplitList(os.Getenv("PATH"))...)
+	// check the default cni bin path first, otherwise look in the rest of the PATH
+	defaultCNIBinPath = append([]string{"/opt/cni/bin"}, filepath.SplitList(os.Getenv("PATH"))...)
 )
 
 // Node configuration is used to configure the node process as well
 // as the virtual machines it produces
 type NodeConfiguration struct {
+	BinPath            []string          `json:"bin_path"`
 	CNI                 CNIDefinition     `json:"cni"`
 	DefaultResourceDir  string            `json:"default_resource_dir"`
 	ForceDepInstall     bool              `json:"-"`
@@ -72,8 +76,9 @@ type Limiters struct {
 // Defines a reference to the CNI network name, which is defined and configured in a {network}.conflist file, as per
 // CNI convention
 type CNIDefinition struct {
-	InterfaceName *string `json:"interface_name"`
-	NetworkName   *string `json:"network_name"`
+	BinPath       []string `json:"bin_path"`
+	InterfaceName *string  `json:"interface_name"`
+	NetworkName   *string  `json:"network_name"`
 }
 
 // Defines the CPU and memory usage of a machine to be configured when it is added to the pool
@@ -104,7 +109,9 @@ func DefaultNodeConfiguration() NodeConfiguration {
 	defaultMemSizeMib := defaultNodeMemSizeMib
 
 	return NodeConfiguration{
+		BinPath: defaultBinPath,
 		CNI: CNIDefinition{
+			BinPath:       defaultCNIBinPath,
 			NetworkName:   agentapi.StringOrNil(defaultCNINetworkName),
 			InterfaceName: agentapi.StringOrNil(defaultCNIInterfaceName),
 		},

--- a/internal/node/running_vm.go
+++ b/internal/node/running_vm.go
@@ -206,6 +206,7 @@ func generateFirecrackerConfig(id string, config *NodeConfiguration) (firecracke
 			AllowMMDS: true,
 			// Use CNI to get dynamic IP
 			CNIConfiguration: &firecracker.CNIConfiguration{
+				BinPath:     config.CNI.BinPath,
 				IfName:      *config.CNI.InterfaceName,
 				NetworkName: *config.CNI.NetworkName,
 			},

--- a/spec/node_test.go
+++ b/spec/node_test.go
@@ -79,11 +79,15 @@ var _ = Describe("nex node", func() {
 
 			snapshotAgentRootFSPath = filepath.Join(os.TempDir(), fmt.Sprintf("%d-rootfs.ext4", _fixtures.seededRand.Int()))
 			cmd := exec.Command("go", "run", "../agent/fc-image", "../agent/cmd/nex-agent/nex-agent")
-			_ = cmd.Start()
-			_ = cmd.Wait()
+			_, err = cmd.CombinedOutput()
+			Expect(err).To(BeNil())
+			Expect(cmd.ProcessState.ExitCode()).To(BeZero())
 
-			compressedRootFS, _ := os.Open("./rootfs.ext4.gz")
-			uncompressedRootFS, _ := gzip.NewReader(bufio.NewReader(compressedRootFS))
+			compressedRootFS, err := os.Open("./rootfs.ext4.gz")
+			Expect(err).To(BeNil())
+
+			uncompressedRootFS, err := gzip.NewReader(bufio.NewReader(compressedRootFS))
+			Expect(err).To(BeNil())
 
 			outFile, _ := os.Create(snapshotAgentRootFSPath)
 			defer outFile.Close()


### PR DESCRIPTION
- adds `BinPath` to CNI node config and passes this through to CNI.
- defaults CNI bin path to match the process `PATH`, pre-pending `/opt/cni/bin` first.
- adds preflight support to check multiple directories instead of just one.
- defaults the user binaries directory list to match the process `PATH`, pre-pending `/usr/local/bin` first.
- if installation of missing dependencies is desired, they are installed in the first entry in the directory lists e.g. `/opt/cni/bin`, `/usr/local/bin` which preserves the current behaviour.

This change is designed to make it easier to integrate with Nix, where binaries are not installed in the usual places. More generally I think it provides better ergonomics to check in the `PATH`.