### PR TITLE
Fixes related to `node_stopped` msg publish and otel panic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
     - 
       name: Run spec suite
       working-directory: .
-      run: sudo -E ~/go/bin/ginkgo run -r --randomize-all --vv --trace --keep-going --output-interceptor-mode=none ./spec
+      run: sudo -E go run github.com/onsi/ginkgo/v2/ginkgo -r --randomize-all --randomize-suites --vv --trace --keep-going --output-interceptor-mode=none ./spec
     - 
       name: Run test suite
       working-directory: .

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,7 +50,7 @@ tasks:
   test:
     deps: [clean, agent]
     cmds:
-      - sudo $GOPATH/bin/ginkgo run -r --randomize-all --vv --trace --keep-going ./spec #--cover --coverprofile=.coverage-report.out
+      - sudo go run github.com/onsi/ginkgo/v2/ginkgo -r --randomize-all --randomize-suites --vv --trace --keep-going ./spec #--cover --coverprofile=.coverage-report.out
       - go test -v -race ./test
 
   ui:

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,6 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
-github.com/onsi/ginkgo/v2 v2.13.2 h1:Bi2gGVkfn6gQcjNjZJVO8Gf0FHzMPf2phUei9tejVMs=
-github.com/onsi/ginkgo/v2 v2.13.2/go.mod h1:XStQ8QcGwLyF4HdfcZB8SFOS/MWCgDuXMSBe6zrvLgM=
 github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -504,8 +502,6 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
-golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -617,8 +613,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
-golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
 golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
 golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/node/agentcomms.go
+++ b/internal/node/agentcomms.go
@@ -67,7 +67,7 @@ func (mgr *MachineManager) handleAgentEvent(m *nats.Msg) {
 	}
 	mgr.log.Info("Received agent event", slog.String("vmid", vmId), slog.String("type", evt.Type()))
 
-	err = mgr.PublishCloudEvent(vm.namespace, evt)
+	err = PublishCloudEvent(mgr.nc, vm.namespace, evt, mgr.log)
 	if err != nil {
 		mgr.log.Error("Failed to publish cloudevent", slog.Any("err", err))
 		return

--- a/internal/node/controlapi.go
+++ b/internal/node/controlapi.go
@@ -201,13 +201,7 @@ func (api *ApiListener) handleDeploy(m *nats.Msg) {
 		return
 	}
 
-	runningVM, err := api.mgr.TakeFromPool()
-	if err != nil {
-		api.log.Error("Failed to get warm VM from pool", slog.Any("err", err))
-		respondFail(controlapi.RunResponseType, m, fmt.Sprintf("Failed to pull warm VM from ready pool: %s", err))
-		return
-	}
-
+	runningVM := <-api.mgr.warmVms
 	workloadName := request.DecodedClaims.Subject
 
 	api.log.

--- a/internal/node/events.go
+++ b/internal/node/events.go
@@ -1,16 +1,11 @@
 package nexnode
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
-	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go"
-	"github.com/google/uuid"
-	agentapi "github.com/synadia-io/nex/internal/agent-api"
-	controlapi "github.com/synadia-io/nex/internal/control-api"
+	"github.com/nats-io/nats.go"
 )
 
 // FIXME-- move this to types repo-- audit other places where it is redeclared (nex-cli)
@@ -20,99 +15,17 @@ type emittedLog struct {
 	MachineId string     `json:"machine_id"`
 }
 
-// PublishCloudEvent writes the given $NEX event to an arbitrary namespace
-func (m *MachineManager) PublishCloudEvent(namespace string, event cloudevents.Event) error {
+// publish the given $NEX event to an arbitrary namespace using the given NATS connection
+func PublishCloudEvent(nc *nats.Conn, namespace string, event cloudevents.Event, log *slog.Logger) error {
 	raw, _ := event.MarshalJSON()
 
 	// $NEX.events.{namespace}.{event_type}
 	subject := fmt.Sprintf("%s.%s.%s", EventSubjectPrefix, namespace, event.Type())
-	err := m.nc.Publish(subject, raw)
+	err := nc.Publish(subject, raw)
 	if err != nil {
-		m.log.Error("Failed to publish cloud event", slog.Any("err", err))
+		log.Error("Failed to publish cloud event", slog.Any("err", err))
+		return err
 	}
 
-	return m.nc.Flush()
-}
-
-// PublishMachineStopped writes a workload stopped event for the provided firecracker VM
-func (m *MachineManager) PublishMachineStopped(vm *runningFirecracker) error {
-	workloadName := strings.TrimSpace(vm.deployRequest.DecodedClaims.Subject)
-	if len(workloadName) > 0 {
-		workloadStopped := struct {
-			Name   string `json:"name"`
-			Reason string `json:"reason,omitempty"`
-			VmId   string `json:"vmid"`
-		}{
-			Name:   workloadName,
-			Reason: "Workload shutdown requested",
-			VmId:   vm.vmmID,
-		}
-
-		cloudevent := cloudevents.NewEvent()
-		cloudevent.SetSource(m.publicKey)
-		cloudevent.SetID(uuid.NewString())
-		cloudevent.SetTime(time.Now().UTC())
-		cloudevent.SetType(agentapi.WorkloadStoppedEventType)
-		cloudevent.SetDataContentType(cloudevents.ApplicationJSON)
-		_ = cloudevent.SetData(workloadStopped)
-
-		err := m.PublishCloudEvent(vm.namespace, cloudevent)
-		if err != nil {
-			return err
-		}
-
-		emitLog := emittedLog{
-			Text:      "Workload stopped",
-			Level:     slog.LevelDebug,
-			MachineId: vm.vmmID,
-		}
-		logBytes, _ := json.Marshal(emitLog)
-
-		subject := fmt.Sprintf("%s.%s.%s.%s.%s", LogSubjectPrefix, vm.namespace, m.publicKey, workloadName, vm.vmmID)
-		err = m.nc.Publish(subject, logBytes)
-		if err != nil {
-			m.log.Error("Failed to publish machine stopped event", slog.Any("err", err))
-		}
-
-		return m.nc.Flush()
-	}
-
-	return nil
-}
-
-// PublishNodeStarted emits a node_started event
-func (m *MachineManager) PublishNodeStarted() error {
-	nodeStart := controlapi.NodeStartedEvent{
-		Version: VERSION,
-		Id:      m.publicKey,
-	}
-
-	cloudevent := cloudevents.NewEvent()
-	cloudevent.SetSource(m.publicKey)
-	cloudevent.SetID(uuid.NewString())
-	cloudevent.SetTime(time.Now().UTC())
-	cloudevent.SetType(controlapi.NodeStartedEventType)
-	cloudevent.SetDataContentType(cloudevents.ApplicationJSON)
-	_ = cloudevent.SetData(nodeStart)
-
-	return m.PublishCloudEvent("system", cloudevent)
-}
-
-// PublishNodeStopped emits a node_stopped event
-func (m *MachineManager) PublishNodeStopped() error {
-	evt := controlapi.NodeStoppedEvent{
-		Id:       m.publicKey,
-		Graceful: true,
-	}
-
-	cloudevent := cloudevents.NewEvent()
-	cloudevent.SetSource(m.publicKey)
-	cloudevent.SetID(uuid.NewString())
-	cloudevent.SetTime(time.Now().UTC())
-	cloudevent.SetType(controlapi.NodeStoppedEventType)
-	cloudevent.SetDataContentType(cloudevents.ApplicationJSON)
-	_ = cloudevent.SetData(evt)
-
-	m.log.Info("Publishing node stopped")
-	return m.PublishCloudEvent("system", cloudevent)
+	return nc.Flush()
 }

--- a/internal/node/machine_mgr.go
+++ b/internal/node/machine_mgr.go
@@ -107,7 +107,7 @@ func NewMachineManager(
 }
 
 // Start the machine manager, maintaining the firecracker VM pool
-func (m *MachineManager) Start() error {
+func (m *MachineManager) Start() {
 	m.log.Info("Virtual machine manager starting")
 
 	defer func() {
@@ -119,7 +119,7 @@ func (m *MachineManager) Start() error {
 	for !m.stopping() {
 		select {
 		case <-m.ctx.Done():
-			return nil
+			return
 		default:
 			vm, err := createAndStartVM(m.ctx, m.config, m.log)
 			if err != nil {
@@ -139,8 +139,6 @@ func (m *MachineManager) Start() error {
 			m.t.vmCounter.Add(m.ctx, 1)
 		}
 	}
-
-	return nil
 }
 
 func (m *MachineManager) DeployWorkload(vm *runningFirecracker, request *agentapi.DeployRequest) error {

--- a/internal/node/machine_mgr.go
+++ b/internal/node/machine_mgr.go
@@ -264,10 +264,10 @@ func (m *MachineManager) Stop() error {
 			m.t.allocatedMemoryCounter.Add(m.ctx, *vm.machine.Cfg.MachineCfg.MemSizeMib*-1, metric.WithAttributes(attribute.String("namespace", vm.namespace)))
 		}
 
-		_ = m.nc.Drain()
-		m.cleanSockets()
-
 		_ = m.PublishNodeStopped()
+		_ = m.nc.Drain()
+
+		m.cleanSockets()
 	}
 
 	return nil

--- a/spec/node_test.go
+++ b/spec/node_test.go
@@ -69,12 +69,13 @@ var _ = Describe("nex node", func() {
 			stopDaggerEngine()
 
 			// require the nex-agent binary to be built... FIXME-- build it here insteaad of relying on the Taskfile
-			_, err := os.Stat("../agent/cmd/nex-agent")
+			_, err := os.Stat("../agent/cmd/nex-agent/nex-agent")
 			Expect(err).To(BeNil())
 
 			snapshotAgentRootFSPath = filepath.Join(os.TempDir(), fmt.Sprintf("%d-rootfs.ext4", _fixtures.seededRand.Int()))
 			cmd := exec.Command("go", "run", "../agent/fc-image", "../agent/cmd/nex-agent/nex-agent")
-			_, _ = cmd.Output()
+			_ = cmd.Start()
+			_ = cmd.Wait()
 
 			compressedRootFS, _ := os.Open("./rootfs.ext4.gz")
 			uncompressedRootFS, _ := gzip.NewReader(bufio.NewReader(compressedRootFS))


### PR DESCRIPTION
This PR fixes the following issues:

- Publish `node_stopped` message prior to draining NATS connection
- Use noop meter provider when otel metrics are disabled -- this fixes a panic

The spec suite is now being called with `go run github.com/onsi/ginkgo/v2/ginkgo` when running locally (`task test`) as well as in GitHub actions.