### PR TITLE
Add cooldown to spec suite cleanup

### DIFF
--- a/spec/spec_suite_test.go
+++ b/spec/spec_suite_test.go
@@ -67,6 +67,8 @@ func cleanupFixtures() {
 	_fixtures.natsServer.WaitForShutdown()
 
 	os.RemoveAll(_fixtures.natsStoreDir)
+
+	time.Sleep(time.Millisecond * 5000)
 }
 
 func startNATS(storeDir string) (*server.Server, *nats.Conn, *int, error) {


### PR DESCRIPTION
The intent of this is to allow github actions runners to win the race to gracefully shutdown running node instances prior to the ginkgo suite exiting.