### PR TITLE
Adds max bytes setting to ad hoc storage for devrun

### DIFF
--- a/nex/devrunner.go
+++ b/nex/devrunner.go
@@ -28,7 +28,9 @@ const (
 	defaultWorkloadType = agentapi.NexExecutionProviderELF
 	fileExtensionJS     = "js"
 	fileExtensionWasm   = "wasm"
+
 	objectStoreName     = "NEXCLIFILES"
+	objectStoreMaxBytes = 100 * 1024 * 1024 // 100 MB
 )
 
 func init() {
@@ -141,6 +143,7 @@ func uploadWorkload(nc *nats.Conn, filename string) (string, string, string, err
 		bucket, err = js.CreateObjectStore(&nats.ObjectStoreConfig{
 			Bucket:      objectStoreName,
 			Description: "Ad hoc object storage for NEX CLI developer mode uploads",
+			MaxBytes:    objectStoreMaxBytes,
 		})
 		if err != nil {
 			return "", "", "", err


### PR DESCRIPTION
In many situations, including NGS/Synadia Cloud, you can't create object store buckets without specifying a maximum number of bytes. To keep the `devrun` option the easiest way to get started, this adds a max bytes of **100MB** to the configuration.

The worst case scenario is eventually the developer has a workload that's > 100MB, and they have to update the bucket configuration.