### PR TITLE
Fix default slog initialization

### DIFF
--- a/nex/nex.go
+++ b/nex/nex.go
@@ -139,7 +139,7 @@ func main() {
 	if Opts.LogJSON {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, &opts))
 	} else {
-		logger = slog.Default()
+		logger = slog.New(slog.NewTextHandler(os.Stdout, &opts))
 	}
 
 	switch cmd {


### PR DESCRIPTION
The `--loglevel` option was no longer being applied.