### PR TITLE
Adds a friendly hostname tag to node ls output

### DIFF
--- a/nex/nodes.go
+++ b/nex/nodes.go
@@ -101,10 +101,14 @@ func renderNodeList(nodes []controlapi.PingResponse) {
 	}
 
 	table := newTableWriter("NATS Execution Nodes")
-	table.AddHeaders("ID", "Version", "Uptime", "Workloads")
+	table.AddHeaders("ID", "Hostname", "Version", "Uptime", "Workloads")
 
 	for _, node := range nodes {
-		table.AddRow(node.NodeId, node.Version, node.Uptime, node.RunningMachines)
+		hostName, ok := node.Tags["hostname"]
+		if !ok {
+			hostName = ""
+		}
+		table.AddRow(node.NodeId, hostName, node.Version, node.Uptime, node.RunningMachines)
 	}
 
 	fmt.Println(table.Render())


### PR DESCRIPTION
Adds configurable friendly name to `node ls` output

```
╭────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                        NATS Execution Nodes                                        │
├──────────────────────────────────────────────────────────┬──────────┬─────────┬────────┬───────────┤
│ ID                                                       │ Hostname │ Version │ Uptime │ Workloads │
├──────────────────────────────────────────────────────────┼──────────┼─────────┼────────┼───────────┤
│ NCNEPHS6GWK33USX4NUTHQKFEW6NYVMHQD7R2MUOKX6NGZBOI4T2AJAP │ my-nex   │ 0.1.5   │ 30m17s │         0 │
╰──────────────────────────────────────────────────────────┴──────────┴─────────┴────────┴───────────╯
```
via 
```
{
    "default_resource_dir": “/etc/wd,
    "machine_pool_size": 1,
    "cni": {
        "network_name": "fcnet",
        "interface_name": "veth0"
    },
    "machine_template": {
        "vcpu_count": 1,
        "memsize_mib": 256
    },
    "tags": {
        "hostname": "my-nex"
    }
}
```