### PR TITLE
allow agent to pull its metadata from environment

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -61,8 +62,8 @@ func NewAgent(ctx context.Context, cancelF context.CancelFunc) (*Agent, error) {
 	var metadata *agentapi.MachineMetadata
 	var err error
 
-	if os.Getenv(nexEnvSandbox) == "false" {
-		metadata, err = GetMachineDataFromEnv()
+	if strings.ToLower(os.Getenv(nexEnvSandbox)) == "false" {
+		metadata, err = GetMachineMetadataFromEnv()
 	} else {
 		metadata, err = GetMachineMetadata()
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -58,14 +58,21 @@ func HaltVM(err error) {
 
 // Initialize a new agent to facilitate communications with the host
 func NewAgent(ctx context.Context, cancelF context.CancelFunc) (*Agent, error) {
-	metadata, err := GetMachineMetadata()
+	var metadata *agentapi.MachineMetadata
+	var err error
+
+	if os.Getenv(nexEnvSandbox) == "false" {
+		metadata, err = GetMachineDataFromEnv()
+	} else {
+		metadata, err = GetMachineMetadata()
+	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get mmds data: %s", err)
+		fmt.Fprintf(os.Stderr, "failed to get machine metadata: %s", err)
 		return nil, err
 	}
 
 	if !metadata.Validate() {
-		return nil, fmt.Errorf("invalid metadata retrieved from mmds; %v", metadata.Errors)
+		return nil, fmt.Errorf("invalid metadata: %v", metadata.Errors)
 	}
 
 	nc, err := nats.Connect(fmt.Sprintf("nats://%s:%d", *metadata.NodeNatsHost, *metadata.NodeNatsPort))
@@ -105,8 +112,6 @@ func (a *Agent) FullVersion() string {
 // Start the agent
 // NOTE: agent process will request vm shutdown if this fails
 func (a *Agent) Start() {
-	// n.log.Info("starting agent")
-
 	err := a.init()
 	if err != nil {
 		panic(err)
@@ -129,8 +134,6 @@ func (a *Agent) Start() {
 			time.Sleep(runloopSleepInterval)
 		}
 	}
-
-	// a.log.Info("exiting agent")
 	a.cancelF()
 }
 

--- a/agent/metadata.go
+++ b/agent/metadata.go
@@ -67,7 +67,7 @@ func GetMachineMetadata() (*agentapi.MachineMetadata, error) {
 	return nil, fmt.Errorf("failed to obtain metadata after %dms", metadataPollingTimeoutMillis)
 }
 
-func GetMachineDataFromEnv() (*agentapi.MachineMetadata, error) {
+func GetMachineMetadataFromEnv() (*agentapi.MachineMetadata, error) {
 	vmid := os.Getenv(nexEnvWorkloadID)
 	host := os.Getenv(nexEnvNodeNatsHost)
 	port := os.Getenv(nexEnvNodeNatsPort)

--- a/agent/metadata.go
+++ b/agent/metadata.go
@@ -19,8 +19,8 @@ const MmdsAddress = "169.254.169.254"
 
 const nexEnvSandbox = "NEX_SANDBOX"
 const nexEnvWorkloadID = "NEX_WORKLOADID"
-const nexEnvNodeNatsHost = "NEX_NODENATSHOST"
-const nexEnvNodeNatsPort = "NEX_NODENATSPORT"
+const nexEnvNodeNatsHost = "NEX_NODE_NATS_HOST"
+const nexEnvNodeNatsPort = "NEX_NODE_NATS_PORT"
 
 const metadataClientTimeoutMillis = 50
 const metadataPollingTimeoutMillis = 5000

--- a/agent/metadata.go
+++ b/agent/metadata.go
@@ -18,7 +18,7 @@ import (
 const MmdsAddress = "169.254.169.254"
 
 const nexEnvSandbox = "NEX_SANDBOX"
-const nexEnvVmID = "NEX_VMID"
+const nexEnvWorkloadID = "NEX_WORKLOADID"
 const nexEnvNodeNatsHost = "NEX_NODENATSHOST"
 const nexEnvNodeNatsPort = "NEX_NODENATSPORT"
 
@@ -68,7 +68,7 @@ func GetMachineMetadata() (*agentapi.MachineMetadata, error) {
 }
 
 func GetMachineDataFromEnv() (*agentapi.MachineMetadata, error) {
-	vmid := os.Getenv(nexEnvVmID)
+	vmid := os.Getenv(nexEnvWorkloadID)
 	host := os.Getenv(nexEnvNodeNatsHost)
 	port := os.Getenv(nexEnvNodeNatsPort)
 	msg := "Metadata obtained from no-sandbox environment"


### PR DESCRIPTION
In order to eventually support the no-sandbox mode, agents will need a way to get the NATS internal IP and port and the workloadId that it's been assigned from the node.

This PR makes it so that if the `NEX_SANDBOX` environment variable both exists and contains the value "false", then the agent will skip the MMDS query. When the agent is running in a sandbox (firecracker + rootfs), the agent is running as an openrc service and so won't have that env var.