### PR TITLE
Expand node test coverage for non-sandbox mode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -161,8 +161,14 @@ func (a *Agent) requestHandshake() error {
 
 	resp, err := a.nc.Request(fmt.Sprintf("agentint.%s.handshake", *a.md.VmID), raw, time.Millisecond*defaultAgentHandshakeTimeoutMillis)
 	if err != nil {
-		a.LogError(fmt.Sprintf("Agent failed to request initial sync message: %s", err))
-		return err
+		if errors.Is(err, nats.ErrNoResponders) {
+			resp, err = a.nc.Request(fmt.Sprintf("agentint.%s.handshake", *a.md.VmID), raw, time.Millisecond*defaultAgentHandshakeTimeoutMillis)
+		}
+
+		if err != nil {
+			a.LogError(fmt.Sprintf("Agent failed to request initial sync message: %s", err))
+			return err
+		}
 	}
 
 	var handshakeResponse *agentapi.HandshakeResponse

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -162,6 +162,7 @@ func (a *Agent) requestHandshake() error {
 	resp, err := a.nc.Request(fmt.Sprintf("agentint.%s.handshake", *a.md.VmID), raw, time.Millisecond*defaultAgentHandshakeTimeoutMillis)
 	if err != nil {
 		if errors.Is(err, nats.ErrNoResponders) {
+			time.Sleep(time.Millisecond * 50)
 			resp, err = a.nc.Request(fmt.Sprintf("agentint.%s.handshake", *a.md.VmID), raw, time.Millisecond*defaultAgentHandshakeTimeoutMillis)
 		}
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -265,13 +265,7 @@ func (n *Node) startInternalNATS() error {
 		return err
 	}
 
-	// this is a non-blocking call
 	n.natsint.Start()
-	if n.config.NoSandbox {
-		// on some systems with many cores, the first pool agent can start before internal NATS is listening
-		// so the agent will get "no responders"
-		time.Sleep(500 * time.Millisecond)
-	}
 
 	clientUrl, err := url.Parse(n.natsint.ClientURL())
 	if err != nil {

--- a/internal/node/processmanager/firecracker_procman.go
+++ b/internal/node/processmanager/firecracker_procman.go
@@ -155,8 +155,7 @@ func (f *FirecrackerProcessManager) Start(delegate ProcessDelegate) error {
 			f.allVMs[vm.vmmID] = vm
 			f.stopMutex[vm.vmmID] = &sync.Mutex{}
 
-			// FIXME-- make vmCounter acessible
-			// f.t.vmCounter.Add(f.ctx, 1)
+			f.t.VmCounter.Add(f.ctx, 1)
 
 			go f.delegate.OnProcessStarted(vm.vmmID)
 

--- a/spec/node_test.go
+++ b/spec/node_test.go
@@ -400,7 +400,7 @@ var _ = Describe("nex node", func() {
 											Subscriptions: true,
 											Test:          fmt.Sprintf("agentint.%s.handshake", workload.Id),
 										})
-										Expect(subsz.Subs[0].Msgs).To(Equal(int64(nodeProxy.NodeConfiguration().MachinePoolSize)))
+										Expect(subsz.Subs[0].Msgs).To(Equal(1))
 									}
 								})
 

--- a/spec/node_test.go
+++ b/spec/node_test.go
@@ -393,13 +393,16 @@ var _ = Describe("nex node", func() {
 
 						Describe("VM pool", func() {
 							Context("when no workloads have been deployed", func() {
-								// It("should complete an agent handshake for each VM in the configured pool size", func(ctx SpecContext) {
-								// 	subsz, _ := nodeProxy.InternalNATS().Subsz(&server.SubszOptions{
-								// 		Subscriptions: true,
-								// 		Test:          "agentint.*.handshake",
-								// 	})
-								// 	Expect(subsz.Subs[0].Msgs).To(Equal(int64(nodeProxy.NodeConfiguration().MachinePoolSize)))
-								// })
+								It("should complete an agent handshake for each VM in the configured pool size", func(ctx SpecContext) {
+									workloads, _ := nodeProxy.WorkloadManager().RunningWorkloads()
+									for _, workload := range workloads {
+										subsz, _ := nodeProxy.InternalNATS().Subsz(&server.SubszOptions{
+											Subscriptions: true,
+											Test:          fmt.Sprintf("agentint.%s.handshake", workload.Id),
+										})
+										Expect(subsz.Subs[0].Msgs).To(Equal(int64(nodeProxy.NodeConfiguration().MachinePoolSize)))
+									}
+								})
 
 								// It("should keep a reference to all running agent processes", func(ctx SpecContext) {
 								// 	Expect(len(managerProxy.AllAgents())).To(Equal(nodeProxy.NodeConfiguration().MachinePoolSize))


### PR DESCRIPTION
The node spec suite now tests the node in sandbox and non-sandbox mode.

All node specs defined within `Describe("up")` are exercised within both sandbox and no-sandbox contexts.