### PR TITLE
Ping can now optionally filter by workload ID or name

### DIFF
--- a/control-api/client.go
+++ b/control-api/client.go
@@ -138,7 +138,7 @@ func (api *Client) ListNodesWithWorkload(workloadId string) ([]PingResponse, err
 		responses = append(responses, resp)
 	})
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	msg := nats.NewMsg(fmt.Sprintf("%s.WPING.%s.%s", APIPrefix, api.namespace, workloadId))
 	msg.Reply = sub.Subject

--- a/internal/node/controlapi.go
+++ b/internal/node/controlapi.go
@@ -335,7 +335,8 @@ func (api *ApiListener) handleWorkloadPing(m *nats.Msg) {
 	}
 	now := time.Now().UTC()
 	for _, machine := range machines {
-		if machine.Namespace == namespace && machine.Id == workloadId {
+		if machine.Namespace == namespace &&
+			(machine.Id == workloadId || strings.EqualFold(machine.Workload.Name, workloadId)) {
 			res := controlapi.NewEnvelope(controlapi.PingResponseType, controlapi.PingResponse{
 				NodeId:          api.PublicKey(),
 				Version:         Version(),

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -122,11 +122,6 @@ func NewWorkloadManager(
 		return nil, err
 	}
 
-	if err != nil {
-		w.log.Error("Failed to initialize agent process manager", slog.Any("error", err))
-		return nil, err
-	}
-
 	w.hostServices = NewHostServices(w, nc, ncint, w.log)
 	err = w.hostServices.init()
 	if err != nil {

--- a/nex/nex.go
+++ b/nex/nex.go
@@ -122,6 +122,9 @@ func init() {
 	rootfs.Flag("image", "Base image for rootfs build").Default("synadia/nex-rootfs:alpine").StringVar(&RootfsOpts.BaseImage)
 	rootfs.Flag("agent", "Path to agent binary").PlaceHolder("../path/to/nex-agent").Required().StringVar(&RootfsOpts.AgentBinaryPath)
 	rootfs.Flag("size", "Size of rootfs filesystem").Default(strconv.Itoa(1024 * 1024 * 150)).IntVar(&RootfsOpts.RootFSSize) // 150MB default
+
+	// one day when we refactor, let's get rid of all of these global structs. Such ugly
+	nodesLs.Flag("workload", "Only query nodes currently running the given workload").StringVar(&RunOpts.Name)
 }
 
 func main() {

--- a/nex/nex.go
+++ b/nex/nex.go
@@ -124,7 +124,7 @@ func init() {
 	rootfs.Flag("size", "Size of rootfs filesystem").Default(strconv.Itoa(1024 * 1024 * 150)).IntVar(&RootfsOpts.RootFSSize) // 150MB default
 
 	// one day when we refactor, let's get rid of all of these global structs. Such ugly
-	nodesLs.Flag("workload", "Only query nodes currently running the given workload").StringVar(&RunOpts.Name)
+	nodesLs.Flag("workload", "Only query nodes currently running the given workload (id or name)").StringVar(&RunOpts.Name)
 }
 
 func main() {

--- a/nex/nodes.go
+++ b/nex/nodes.go
@@ -22,7 +22,13 @@ func ListNodes(ctx context.Context) error {
 	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	nodeClient := controlapi.NewApiClient(nc, Opts.Timeout, log)
 
-	nodes, err := nodeClient.ListNodes()
+	var nodes []controlapi.PingResponse
+	if strings.TrimSpace(RunOpts.Name) != "" {
+		nodes, err = nodeClient.ListNodesWithWorkload(strings.TrimSpace(RunOpts.Name))
+	} else {
+		nodes, err = nodeClient.ListNodes()
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
You can now use a different `WPING` endpoint to have nodes _only_ reply to a ping if they're currently running the indicated workload, which can be the workload ID or the workload name.

So if you specify a workload ID, you should expect 0 or 1 nodes.
If you specify a workload name, you might get multiple nodes if that workload is scaled out.

Added the `--workload` option to the `node ls` command, so the end user doesn't need to know that this is a different ping subject under the hood.