### PR TITLE
Remove OtelCol healthcheck

### DIFF
--- a/_scripts/otel/otel-collector.yaml
+++ b/_scripts/otel/otel-collector.yaml
@@ -37,5 +37,3 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [debug]
-
-  extensions: [health_check]


### PR DESCRIPTION
Not needed for dev OTel and opens an unneeded port