### PR TITLE
Cleanup host services

### DIFF
--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -67,7 +67,6 @@ const (
 	v8FunctionArrayInit          = "array-init"
 	v8FunctionUInt8ArrayInit     = "uint8-array-init"
 	v8FunctionUInt8ArraySetIdx   = "uint8-array-set-idx"
-	v8FunctionUInt8ArrayToArray  = "uint8-array-to-array"
 	v8FunctionUInt8ArrayToString = "uint8-array-to-string"
 
 	v8ExecutionTimeoutMillis = 5000
@@ -272,11 +271,6 @@ func (v *V8) initUtils() {
 	uint8arrsetidxval, _ := uint8arrsetidx.Run(v.ctx)
 	uint8arrsetidxfn, _ := uint8arrsetidxval.AsFunction()
 	v.utils[v8FunctionUInt8ArraySetIdx] = uint8arrsetidxfn
-
-	uint8arrtoarr, _ := v.iso.CompileUnboundScript("(arr) => { return Array.prototype.slice.call(arr); };", "uint8-array-to-array.js", v8.CompileOptions{})
-	uint8arrtoarrval, _ := uint8arrtoarr.Run(v.ctx)
-	uint8arrtoarrfn, _ := uint8arrtoarrval.AsFunction()
-	v.utils[v8FunctionUInt8ArrayToArray] = uint8arrtoarrfn
 
 	uint8arrtostr, _ := v.iso.CompileUnboundScript("(arr) => { return String.fromCharCode(...arr); };", "uint8-array-to-string.js", v8.CompileOptions{})
 	uint8arrtostrval, _ := uint8arrtostr.Run(v.ctx)

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -63,17 +63,6 @@ const (
 	hostServicesObjectStoreDeleteTimeout = time.Millisecond * 3000
 	hostServicesObjectStoreListTimeout   = time.Millisecond * 3000
 
-	nexTriggerSubject = "x-nex-trigger-subject"
-	nexRuntimeNs      = "x-nex-runtime-ns"
-
-	httpURLHeader = "x-http-url"
-
-	keyValueKeyHeader = "x-keyvalue-key"
-
-	messagingSubjectHeader = "x-subject"
-
-	objectStoreObjectNameHeader = "x-object-name"
-
 	v8FunctionArrayAppend = "array-append"
 	v8FunctionArrayInit   = "array-init"
 
@@ -114,7 +103,7 @@ func (v *V8) Deploy() error {
 	subject := fmt.Sprintf("agentint.%s.trigger", v.vmID)
 	_, err := v.nc.Subscribe(subject, func(msg *nats.Msg) {
 		startTime := time.Now()
-		val, err := v.Execute(msg.Header.Get(nexTriggerSubject), msg.Data)
+		val, err := v.Execute(msg.Header.Get(agentapi.NexTriggerSubject), msg.Data)
 		if err != nil {
 			_, _ = v.stderr.Write([]byte(fmt.Sprintf("failed to execute function on trigger subject %s: %s", subject, err.Error())))
 			return
@@ -124,7 +113,7 @@ func (v *V8) Deploy() error {
 		err = msg.RespondMsg(&nats.Msg{
 			Data: val,
 			Header: nats.Header{
-				nexRuntimeNs: []string{strconv.FormatInt(runtimeNanos, 10)},
+				agentapi.NexRuntimeNs: []string{strconv.FormatInt(runtimeNanos, 10)},
 			},
 		})
 		if err != nil {
@@ -347,7 +336,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPGetFunctionName))
-		msg.Header.Add(httpURLHeader, _url.String())
+		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -434,7 +423,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPostFunctionName))
-		msg.Header.Add(httpURLHeader, _url.String())
+		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
 		msg.Data = []byte(data)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
@@ -522,7 +511,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPutFunctionName))
-		msg.Header.Add(httpURLHeader, _url.String())
+		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
 		msg.Data = []byte(data)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
@@ -610,7 +599,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPatchFunctionName))
-		msg.Header.Add(httpURLHeader, _url.String())
+		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
 		msg.Data = []byte(data)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
@@ -687,7 +676,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPDeleteFunctionName))
-		msg.Header.Add(httpURLHeader, _url.String())
+		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -763,7 +752,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPHeadFunctionName))
-		msg.Header.Add(httpURLHeader, _url.String())
+		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -833,7 +822,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		key := args[0].String()
 
 		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVGetFunctionName))
-		msg.Header.Add(keyValueKeyHeader, key)
+		msg.Header.Add(agentapi.KeyValueKeyHeader, key)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesKVGetTimeout)
 		if err != nil {
@@ -866,7 +855,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVSetFunctionName))
-		msg.Header.Add(keyValueKeyHeader, key)
+		msg.Header.Add(agentapi.KeyValueKeyHeader, key)
 		msg.Data = value
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesKVSetTimeout)
@@ -900,7 +889,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		key := args[0].String()
 
 		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVDeleteFunctionName))
-		msg.Header.Add(keyValueKeyHeader, key)
+		msg.Header.Add(agentapi.KeyValueKeyHeader, key)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesKVDeleteTimeout)
 		if err != nil {
@@ -962,7 +951,7 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingPublishFunctionName))
-		msg.Header.Add(messagingSubjectHeader, subject)
+		msg.Header.Add(agentapi.MessagingSubjectHeader, subject)
 		msg.Data = []byte(payload)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesMessagingPublishTimeout)
@@ -996,7 +985,7 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingRequestFunctionName))
-		msg.Header.Add(messagingSubjectHeader, subject)
+		msg.Header.Add(agentapi.MessagingSubjectHeader, subject)
 		msg.Data = []byte(payload)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesMessagingRequestTimeout)
@@ -1033,7 +1022,7 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 
 		// construct the requestMany request message
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingRequestManyFunctionName))
-		msg.Header.Add(messagingSubjectHeader, subject)
+		msg.Header.Add(agentapi.MessagingSubjectHeader, subject)
 		msg.Reply = v.nc.NewRespInbox()
 		msg.Data = []byte(payload)
 
@@ -1111,7 +1100,7 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 		name := args[0].String()
 
 		msg := nats.NewMsg(v.objectStoreServiceSubject(hostServicesObjectStoreGetFunctionName))
-		msg.Header.Add(objectStoreObjectNameHeader, name)
+		msg.Header.Add(agentapi.ObjectStoreObjectNameHeader, name)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesObjectStoreGetTimeout)
 		if err != nil {
@@ -1144,7 +1133,7 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.objectStoreServiceSubject(hostServicesObjectStorePutFunctionName))
-		msg.Header.Add(objectStoreObjectNameHeader, name)
+		msg.Header.Add(agentapi.ObjectStoreObjectNameHeader, name)
 		msg.Data = []byte(value)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesObjectStorePutTimeout)
@@ -1172,7 +1161,7 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 		name := args[0].String()
 
 		msg := nats.NewMsg(v.objectStoreServiceSubject(hostServicesObjectStoreDeleteFunctionName))
-		msg.Header.Add(objectStoreObjectNameHeader, name)
+		msg.Header.Add(agentapi.ObjectStoreObjectNameHeader, name)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesObjectStoreDeleteTimeout)
 		if err != nil {

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -1220,15 +1220,11 @@ func (v *V8) marshalValue(val *v8.Value) ([]byte, error) {
 		return val.MarshalJSON()
 	} else if val.IsBigInt() {
 		return val.BigInt().Bytes(), nil
-	} else if val.IsBoolean() {
-		return []byte(fmt.Sprintf("%t", val.Boolean())), nil
-	} else if val.IsNumber() {
-		return []byte(fmt.Sprintf("%f", val.Number())), nil
 	} else if val.IsString() {
 		return []byte(val.String()), nil
 	}
 
-	return nil, fmt.Errorf("failed to marshal v8 value to []byte: %v", val)
+	return nil, fmt.Errorf("failed to marshal v8 value to []byte: %v; object, arrays, and strings are supported", val)
 }
 
 func (v *V8) toUInt8ArrayValue(data []byte) (*v8.Value, error) {

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -66,6 +66,10 @@ const (
 	nexTriggerSubject = "x-nex-trigger-subject"
 	nexRuntimeNs      = "x-nex-runtime-ns"
 
+	httpURL = "x-http-url"
+
+	keyHeader = "x-key"
+
 	messageSubject = "x-subject"
 
 	objectName = "x-object-name"
@@ -342,12 +346,10 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		req, _ := json.Marshal(&agentapi.HostServicesHTTPRequest{
-			Method: hostServicesHTTPGetFunctionName,
-			URL:    _url.String(),
-		})
+		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPGetFunctionName))
+		msg.Header.Add(httpURL, _url.String())
 
-		resp, err := v.nc.Request(v.httpServiceSubject(hostServicesHTTPGetFunctionName), req, hostServicesHTTPRequestTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -431,13 +433,11 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			}
 		}
 
-		req, _ := json.Marshal(&agentapi.HostServicesHTTPRequest{
-			Method: hostServicesHTTPPostFunctionName,
-			URL:    _url.String(),
-			Body:   &data,
-		})
+		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPostFunctionName))
+		msg.Header.Add(httpURL, _url.String())
+		msg.Data = []byte(data)
 
-		resp, err := v.nc.Request(v.httpServiceSubject(hostServicesHTTPPostFunctionName), req, hostServicesHTTPRequestTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -521,13 +521,11 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			}
 		}
 
-		req, _ := json.Marshal(&agentapi.HostServicesHTTPRequest{
-			Method: hostServicesHTTPPutFunctionName,
-			URL:    _url.String(),
-			Body:   &data,
-		})
+		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPutFunctionName))
+		msg.Header.Add(httpURL, _url.String())
+		msg.Data = []byte(data)
 
-		resp, err := v.nc.Request(v.httpServiceSubject(hostServicesHTTPPutFunctionName), req, hostServicesHTTPRequestTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -611,13 +609,11 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			}
 		}
 
-		req, _ := json.Marshal(&agentapi.HostServicesHTTPRequest{
-			Method: hostServicesHTTPPatchFunctionName,
-			URL:    _url.String(),
-			Body:   &data,
-		})
+		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPatchFunctionName))
+		msg.Header.Add(httpURL, _url.String())
+		msg.Data = []byte(data)
 
-		resp, err := v.nc.Request(v.httpServiceSubject(hostServicesHTTPPatchFunctionName), req, hostServicesHTTPRequestTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -690,24 +686,10 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		var data string
-		if len(args) > 1 {
-			payload := args[1]
-			if payload.IsObject() || payload.IsArray() {
-				payloadJSON, _ := payload.MarshalJSON()
-				data = string(payloadJSON)
-			} else {
-				data = payload.String()
-			}
-		}
+		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPDeleteFunctionName))
+		msg.Header.Add(httpURL, _url.String())
 
-		req, _ := json.Marshal(&agentapi.HostServicesHTTPRequest{
-			Method: hostServicesHTTPDeleteFunctionName,
-			URL:    _url.String(),
-			Body:   &data, // this should not be present for DELETE requests, but it is not explicitly forbidden. so we'll allow it
-		})
-
-		resp, err := v.nc.Request(v.httpServiceSubject(hostServicesHTTPDeleteFunctionName), req, hostServicesHTTPRequestTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -780,12 +762,10 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		req, _ := json.Marshal(&agentapi.HostServicesHTTPRequest{
-			Method: hostServicesHTTPHeadFunctionName,
-			URL:    _url.String(),
-		})
+		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPHeadFunctionName))
+		msg.Header.Add(httpURL, _url.String())
 
-		resp, err := v.nc.Request(v.httpServiceSubject(hostServicesHTTPHeadFunctionName), req, hostServicesHTTPRequestTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -852,24 +832,16 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 
 		key := args[0].String()
 
-		req, _ := json.Marshal(&agentapi.HostServicesKeyValueRequest{
-			Key: &key,
-		})
+		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVGetFunctionName))
+		msg.Header.Add(keyHeader, key)
 
-		resp, err := v.nc.Request(v.keyValueServiceSubject(hostServicesKVGetFunctionName), req, hostServicesKVGetTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesKVGetTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
 		}
 
-		var kvresp *agentapi.HostServicesKeyValueRequest
-		err = json.Unmarshal(resp.Data, &kvresp)
-		if err != nil {
-			val, _ := v8.NewValue(v.iso, err.Error())
-			return v.iso.ThrowException(val)
-		}
-
-		val, err := v8.JSONParse(v.ctx, string(*kvresp.Value))
+		val, err := v8.JSONParse(v.ctx, string(resp.Data)) // FIXME-- support unmarshaling
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -886,27 +858,24 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		key := args[0].String()
-		value := args[1]
 
-		raw, err := value.MarshalJSON() // FIXME-- support Uint8 array
+		value, err := v.marshalValue(args[1])
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
 		}
 
-		val := json.RawMessage(raw)
-		req, _ := json.Marshal(&agentapi.HostServicesKeyValueRequest{
-			Key:   &key,
-			Value: &val,
-		})
+		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVSetFunctionName))
+		msg.Header.Add(keyHeader, key)
+		msg.Data = value
 
-		resp, err := v.nc.Request(v.keyValueServiceSubject(hostServicesKVSetFunctionName), req, hostServicesKVSetTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesKVSetTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
 		}
 
-		var kvresp *agentapi.HostServicesKeyValueRequest
+		var kvresp *agentapi.HostServicesKeyValueResponse
 		err = json.Unmarshal(resp.Data, &kvresp)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
@@ -914,7 +883,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		if !*kvresp.Success {
-			val, _ := v8.NewValue(v.iso, fmt.Sprintf("failed to set %d-byte value for key: %s", len(val), key))
+			val, _ := v8.NewValue(v.iso, fmt.Sprintf("failed to set %d-byte value for key: %s", len(value), key))
 			return v.iso.ThrowException(val)
 		}
 
@@ -930,17 +899,16 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 
 		key := args[0].String()
 
-		req, _ := json.Marshal(&agentapi.HostServicesKeyValueRequest{
-			Key: &key,
-		})
+		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVDeleteFunctionName))
+		msg.Header.Add(keyHeader, key)
 
-		resp, err := v.nc.Request(v.keyValueServiceSubject(hostServicesKVDeleteFunctionName), req, hostServicesKVDeleteTimeout)
+		resp, err := v.nc.RequestMsg(msg, hostServicesKVDeleteTimeout)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
 		}
 
-		var kvresp *agentapi.HostServicesKeyValueRequest
+		var kvresp *agentapi.HostServicesKeyValueResponse
 		err = json.Unmarshal(resp.Data, &kvresp)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
@@ -987,7 +955,11 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		subject := args[0].String()
-		payload := args[1].String()
+		payload, err := v.marshalValue(args[1])
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
+		}
 
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingPublishFunctionName))
 		msg.Header.Add(messageSubject, subject)
@@ -1017,7 +989,11 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		subject := args[0].String()
-		payload := args[1].String()
+		payload, err := v.marshalValue(args[1])
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
+		}
 
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingRequestFunctionName))
 		msg.Header.Add(messageSubject, subject)
@@ -1036,7 +1012,7 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		val, err := v8.NewValue(v.iso, string(resp.Data)) // FIXME-- pass []byte natively into javascript using ArrayBuffer
+		val, err := v8.NewValue(v.iso, string(resp.Data))
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -1160,22 +1136,12 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		name := args[0].String()
-		value := args[1].String()
 
-		// FIXME- resolve primitive value from the following types:
-		//   string -> V8::String
-		//   int32 -> V8::Integer
-		//   uint32 -> V8::Integer
-		//   int64 -> V8::BigInt
-		//   uint64 -> V8::BigInt
-		//   bool -> V8::Boolean
-		//   *big.Int -> V8::BigInt
-
-		// raw, err := value.MarshalJSON() // FIXME-- support Uint8 array
-		// if err != nil {
-		// 	val, _ := v8.NewValue(v.iso, err.Error())
-		// 	return v.iso.ThrowException(val)
-		// }
+		value, err := v.marshalValue(args[1])
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
+		}
 
 		msg := nats.NewMsg(v.objectStoreServiceSubject(hostServicesObjectStorePutFunctionName))
 		msg.Header.Add(objectName, name)
@@ -1248,6 +1214,22 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 	}))
 
 	return objectStore
+}
+
+func (v *V8) marshalValue(val *v8.Value) ([]byte, error) {
+	if val.IsObject() || val.IsArray() {
+		return val.MarshalJSON()
+	} else if val.IsBigInt() {
+		return []byte(val.BigInt().String()), nil
+	} else if val.IsBoolean() {
+		return []byte(fmt.Sprintf("%t", val.Boolean())), nil
+	} else if val.IsNumber() {
+		return []byte(fmt.Sprintf("%f", val.Number())), nil
+	} else if val.IsString() {
+		return []byte(val.String()), nil
+	}
+
+	return nil, fmt.Errorf("failed to marshal v8 value: %v", val)
 }
 
 // convenience method to initialize a V8 execution provider

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -167,8 +167,9 @@ func (v *V8) Execute(subject string, payload []byte) ([]byte, error) {
 			return
 		}
 
-		argv2, err := v8.NewValue(ctx.Isolate(), string(payload))
+		argv2, err := v.toUInt8ArrayValue(payload)
 		if err != nil {
+			_, _ = v.stdout.Write([]byte(fmt.Sprintf("failed to convert raw %d-length []byte to Uint8[]: %s", len(payload), err.Error())))
 			errs <- err
 			return
 		}
@@ -1001,13 +1002,6 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		// var msgresp *agentapi.HostServicesMessagingResponse
-		// err = json.Unmarshal(resp.Data, &msgresp)
-		// if err == nil && len(msgresp.Errors) > 0 {
-		// 	val, _ := v8.NewValue(v.iso, msgresp.Errors[0])
-		// 	return v.iso.ThrowException(val)
-		// }
-
 		val, err := v.toUInt8ArrayValue(resp.Data)
 		if err != nil {
 			_, _ = v.stdout.Write([]byte(fmt.Sprintf("failed to convert raw %d-length []byte to Uint8[]: %s", len(resp.Data), err.Error())))
@@ -1276,10 +1270,6 @@ func InitNexExecutionProviderV8(params *agentapi.ExecutionProviderParams) (*V8, 
 	if params.TmpFilename == nil {
 		return nil, errors.New("V8 execution provider requires a temporary filename parameter")
 	}
-
-	// if params.TotalBytes == nil {
-	// 	return nil, errors.New("V8 execution provider requires a total bytes parameter")
-	// }
 
 	return &V8{
 		environment: params.Environment,

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -68,7 +68,7 @@ const (
 	v8FunctionUInt8ArrayInit     = "uint8-array-init"
 	v8FunctionUInt8ArraySetIdx   = "uint8-array-set-idx"
 	v8FunctionUInt8ArrayToArray  = "uint8-array-to-array"
-	v8FunctionUInt8ArrayToString = "uint8-array-to-bytes"
+	v8FunctionUInt8ArrayToString = "uint8-array-to-string"
 
 	v8ExecutionTimeoutMillis = 5000
 	v8MaxFileSizeBytes       = int64(12288) // arbitrarily ~12K, for now

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -411,20 +411,15 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		var data string
-		if len(args) > 1 {
-			payload := args[1]
-			if payload.IsObject() || payload.IsArray() {
-				payloadJSON, _ := payload.MarshalJSON()
-				data = string(payloadJSON)
-			} else {
-				data = payload.String()
-			}
+		payload, err := v.marshalValue(args[1])
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPostFunctionName))
 		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
-		msg.Data = []byte(data)
+		msg.Data = []byte(payload)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -499,20 +494,15 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		var data string
-		if len(args) > 1 {
-			payload := args[1]
-			if payload.IsObject() || payload.IsArray() {
-				payloadJSON, _ := payload.MarshalJSON()
-				data = string(payloadJSON)
-			} else {
-				data = payload.String()
-			}
+		payload, err := v.marshalValue(args[1])
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPutFunctionName))
 		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
-		msg.Data = []byte(data)
+		msg.Data = []byte(payload)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -587,20 +577,15 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		var data string
-		if len(args) > 1 {
-			payload := args[1]
-			if payload.IsObject() || payload.IsArray() {
-				payloadJSON, _ := payload.MarshalJSON()
-				data = string(payloadJSON)
-			} else {
-				data = payload.String()
-			}
+		payload, err := v.marshalValue(args[1])
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPatchFunctionName))
 		msg.Header.Add(agentapi.HttpURLHeader, _url.String())
-		msg.Data = []byte(data)
+		msg.Data = []byte(payload)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -830,7 +815,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		val, err := v8.JSONParse(v.ctx, string(resp.Data)) // FIXME-- support unmarshaling
+		val, err := v8.NewValue(v.iso, string(resp.Data))
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -1142,7 +1127,7 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		val, err := v8.JSONParse(v.ctx, string(resp.Data))
+		val, err := v8.NewValue(v.iso, string(resp.Data))
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -1229,7 +1229,7 @@ func (v *V8) marshalValue(val *v8.Value) ([]byte, error) {
 	return nil, fmt.Errorf("failed to marshal v8 value to []byte: %v; only Uint8[] is supported", val)
 }
 
-// unmarshal the given []byte value into a native Uint8Array which can be handed back into v8,
+// unmarshal the given []byte value into a native Uint8Array which can be handed back into v8
 func (v *V8) toUInt8ArrayValue(val []byte) (*v8.Value, error) {
 	// initialize a v8 value representing the size in bytes of the native Uint8Array to be allocated
 	len, err := v8.NewValue(v.iso, uint64(len(val)))

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -66,13 +66,13 @@ const (
 	nexTriggerSubject = "x-nex-trigger-subject"
 	nexRuntimeNs      = "x-nex-runtime-ns"
 
-	httpURL = "x-http-url"
+	httpURLHeader = "x-http-url"
 
-	keyHeader = "x-key"
+	keyValueKeyHeader = "x-keyvalue-key"
 
-	messageSubject = "x-subject"
+	messagingSubjectHeader = "x-subject"
 
-	objectName = "x-object-name"
+	objectStoreObjectNameHeader = "x-object-name"
 
 	v8FunctionArrayAppend = "array-append"
 	v8FunctionArrayInit   = "array-init"
@@ -347,7 +347,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPGetFunctionName))
-		msg.Header.Add(httpURL, _url.String())
+		msg.Header.Add(httpURLHeader, _url.String())
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -434,7 +434,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPostFunctionName))
-		msg.Header.Add(httpURL, _url.String())
+		msg.Header.Add(httpURLHeader, _url.String())
 		msg.Data = []byte(data)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
@@ -522,7 +522,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPutFunctionName))
-		msg.Header.Add(httpURL, _url.String())
+		msg.Header.Add(httpURLHeader, _url.String())
 		msg.Data = []byte(data)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
@@ -610,7 +610,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPPatchFunctionName))
-		msg.Header.Add(httpURL, _url.String())
+		msg.Header.Add(httpURLHeader, _url.String())
 		msg.Data = []byte(data)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
@@ -687,7 +687,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPDeleteFunctionName))
-		msg.Header.Add(httpURL, _url.String())
+		msg.Header.Add(httpURLHeader, _url.String())
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -763,7 +763,7 @@ func (v *V8) newHTTPObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.httpServiceSubject(hostServicesHTTPHeadFunctionName))
-		msg.Header.Add(httpURL, _url.String())
+		msg.Header.Add(httpURLHeader, _url.String())
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesHTTPRequestTimeout)
 		if err != nil {
@@ -833,7 +833,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		key := args[0].String()
 
 		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVGetFunctionName))
-		msg.Header.Add(keyHeader, key)
+		msg.Header.Add(keyValueKeyHeader, key)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesKVGetTimeout)
 		if err != nil {
@@ -866,7 +866,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVSetFunctionName))
-		msg.Header.Add(keyHeader, key)
+		msg.Header.Add(keyValueKeyHeader, key)
 		msg.Data = value
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesKVSetTimeout)
@@ -900,7 +900,7 @@ func (v *V8) newKeyValueObjectTemplate() *v8.ObjectTemplate {
 		key := args[0].String()
 
 		msg := nats.NewMsg(v.keyValueServiceSubject(hostServicesKVDeleteFunctionName))
-		msg.Header.Add(keyHeader, key)
+		msg.Header.Add(keyValueKeyHeader, key)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesKVDeleteTimeout)
 		if err != nil {
@@ -962,7 +962,7 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingPublishFunctionName))
-		msg.Header.Add(messageSubject, subject)
+		msg.Header.Add(messagingSubjectHeader, subject)
 		msg.Data = []byte(payload)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesMessagingPublishTimeout)
@@ -996,7 +996,7 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingRequestFunctionName))
-		msg.Header.Add(messageSubject, subject)
+		msg.Header.Add(messagingSubjectHeader, subject)
 		msg.Data = []byte(payload)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesMessagingRequestTimeout)
@@ -1033,7 +1033,7 @@ func (v *V8) newMessagingObjectTemplate() *v8.ObjectTemplate {
 
 		// construct the requestMany request message
 		msg := nats.NewMsg(v.messagingServiceSubject(hostServicesMessagingRequestManyFunctionName))
-		msg.Header.Add(messageSubject, subject)
+		msg.Header.Add(messagingSubjectHeader, subject)
 		msg.Reply = v.nc.NewRespInbox()
 		msg.Data = []byte(payload)
 
@@ -1111,7 +1111,7 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 		name := args[0].String()
 
 		msg := nats.NewMsg(v.objectStoreServiceSubject(hostServicesObjectStoreGetFunctionName))
-		msg.Header.Add(objectName, name)
+		msg.Header.Add(objectStoreObjectNameHeader, name)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesObjectStoreGetTimeout)
 		if err != nil {
@@ -1144,7 +1144,7 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 		}
 
 		msg := nats.NewMsg(v.objectStoreServiceSubject(hostServicesObjectStorePutFunctionName))
-		msg.Header.Add(objectName, name)
+		msg.Header.Add(objectStoreObjectNameHeader, name)
 		msg.Data = []byte(value)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesObjectStorePutTimeout)
@@ -1172,7 +1172,7 @@ func (v *V8) newObjectStoreObjectTemplate() *v8.ObjectTemplate {
 		name := args[0].String()
 
 		msg := nats.NewMsg(v.objectStoreServiceSubject(hostServicesObjectStoreDeleteFunctionName))
-		msg.Header.Add(objectName, name)
+		msg.Header.Add(objectStoreObjectNameHeader, name)
 
 		resp, err := v.nc.RequestMsg(msg, hostServicesObjectStoreDeleteTimeout)
 		if err != nil {

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -1219,7 +1219,7 @@ func (v *V8) marshalValue(val *v8.Value) ([]byte, error) {
 	if val.IsObject() || val.IsArray() {
 		return val.MarshalJSON()
 	} else if val.IsBigInt() {
-		return []byte(val.BigInt().String()), nil
+		return val.BigInt().Bytes(), nil
 	} else if val.IsBoolean() {
 		return []byte(fmt.Sprintf("%t", val.Boolean())), nil
 	} else if val.IsNumber() {
@@ -1228,7 +1228,7 @@ func (v *V8) marshalValue(val *v8.Value) ([]byte, error) {
 		return []byte(val.String()), nil
 	}
 
-	return nil, fmt.Errorf("failed to marshal v8 value: %v", val)
+	return nil, fmt.Errorf("failed to marshal v8 value to []byte: %v", val)
 }
 
 func (v *V8) toUInt8ArrayValue(data []byte) (*v8.Value, error) {

--- a/examples/v8/echofunction/src/echofunction.js
+++ b/examples/v8/echofunction/src/echofunction.js
@@ -2,6 +2,6 @@
   console.log(subject);
   return {
     triggered_on: subject,
-    payload: payload
+    payload: Array.prototype.slice.call(payload)
   }
 };

--- a/examples/v8/echofunction/src/echofunction.js
+++ b/examples/v8/echofunction/src/echofunction.js
@@ -2,6 +2,6 @@
   console.log(subject);
   return {
     triggered_on: subject,
-    payload: Array.prototype.slice.call(payload)
+    payload: String.fromCharCode(...payload)
   }
 };

--- a/examples/v8/echofunction/src/kv.js
+++ b/examples/v8/echofunction/src/kv.js
@@ -5,6 +5,6 @@
   this.hostServices.kv.set('hello2', payload);
   return {
     keys: this.hostServices.kv.keys(),
-    hello2: this.hostServices.kv.get('hello2')
+    hello2: String.fromCharCode(...this.hostServices.kv.get('hello2'))
   }
 };

--- a/examples/v8/echofunction/src/messaging.js
+++ b/examples/v8/echofunction/src/messaging.js
@@ -1,28 +1,38 @@
 (subject, payload) => {
   this.hostServices.messaging.publish('hello.world', payload);
 
-  var req;
+  var reqResp;
   var reqEx;
 
-  var reqMany;
+  var reqManyResp;
   var reqManyEx;
 
   try {
-    req = this.hostServices.messaging.request('hello.world.request', payload);
+    reqResp = this.hostServices.messaging.request('hello.world.request', payload);
+    reqResp = String.fromCharCode(...reqResp)
   } catch (e) {
     reqEx = e;
   }
 
   try {
-    reqMany = this.hostServices.messaging.requestMany('hello.world.request.many', payload);
+    reqManyResp = []
+
+    let responses = this.hostServices.messaging.requestMany('hello.world.request.many', payload)
+  
+    // responses is an array of Uint8Array... flatten it so we can use each value
+    responses = Array.prototype.slice.call(responses)
+
+    for (let i = 0; i < responses.length; i++) {
+      reqManyResp.push(String.fromCharCode(...responses[i]))
+    }
   } catch (e) {
     reqManyEx = e;
   }
 
   return {
-    'hello.world.request': req,
+    'hello.world.request': reqResp,
     'hello.world.request.ex': reqEx,
-    'hello.world.request.many': reqMany,
+    'hello.world.request.many': reqManyResp,
     'hello.world.request.many.ex': reqManyEx
   }
 };

--- a/examples/v8/echofunction/src/objectstore.js
+++ b/examples/v8/echofunction/src/objectstore.js
@@ -5,6 +5,6 @@
   this.hostServices.objectStore.put('hello2', payload);
   return {
     list: this.hostServices.objectStore.list(),
-    hello2: this.hostServices.objectStore.get('hello2')
+    hello2: String.fromCharCode(...this.hostServices.objectStore.get('hello2'))
   }
 };

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -23,7 +23,16 @@ type EventCallback func(string, cloudevents.Event)
 type LogCallback func(string, LogEntry)
 
 const (
-	nexTriggerSubject = "x-nex-trigger-subject"
+	NexTriggerSubject = "x-nex-trigger-subject"
+	NexRuntimeNs      = "x-nex-runtime-ns"
+
+	HttpURLHeader = "x-http-url"
+
+	KeyValueKeyHeader = "x-keyvalue-key"
+
+	MessagingSubjectHeader = "x-subject"
+
+	ObjectStoreObjectNameHeader = "x-object-name"
 )
 
 type AgentClient struct {
@@ -182,7 +191,7 @@ func (a *AgentClient) UptimeMillis() time.Duration {
 func (a *AgentClient) RunTrigger(ctx context.Context, tracer trace.Tracer, subject string, data []byte) (*nats.Msg, error) {
 	intmsg := nats.NewMsg(fmt.Sprintf("agentint.%s.trigger", a.agentID))
 	// TODO: inject tracer context into message header
-	intmsg.Header.Add(nexTriggerSubject, subject)
+	intmsg.Header.Add(NexTriggerSubject, subject)
 	intmsg.Data = data
 
 	cctx, childSpan := tracer.Start(

--- a/internal/agent-api/types.go
+++ b/internal/agent-api/types.go
@@ -169,12 +169,11 @@ type HostServicesHTTPResponse struct {
 	Error *string `json:"error,omitempty"`
 }
 
-type HostServicesKeyValueRequest struct {
-	Key   *string          `json:"key"`
-	Value *json.RawMessage `json:"value,omitempty"`
-
+type HostServicesKeyValueResponse struct {
 	Revision int64 `json:"revision,omitempty"`
 	Success  *bool `json:"success,omitempty"`
+
+	Errors []string `json:"errors,omitempty"`
 }
 
 type HostServicesObjectStoreResponse struct {

--- a/internal/node/services/lib/http.go
+++ b/internal/node/services/lib/http.go
@@ -21,6 +21,8 @@ const httpServiceMethodHead = "head"
 
 const defaultHTTPRequestTimeoutMillis = 2500
 
+const httpURL = "x-http-url"
+
 type HTTPService struct {
 	log *slog.Logger
 	nc  *nats.Conn
@@ -74,23 +76,7 @@ func (h *HTTPService) HandleRPC(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleGet(msg *nats.Msg) {
-	var req *agentapi.HostServicesHTTPRequest
-	err := json.Unmarshal(msg.Data, &req)
-	if err != nil {
-		h.log.Warn(fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	url, err := url.Parse(req.URL)
+	url, err := url.Parse(msg.Header.Get(httpURL))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -109,25 +95,7 @@ func (h *HTTPService) handleGet(msg *nats.Msg) {
 		WithLogger(h.log).
 		WithTimeoutMillis(defaultHTTPRequestTimeoutMillis)
 
-	params := map[string]interface{}{}
-	if req.Params != nil {
-		err = json.Unmarshal(*req.Params, &params)
-		if err != nil {
-			h.log.Debug("failed to unmarshal query params for http RPC request", slog.String("error", err.Error()))
-
-			resp, _ := json.Marshal(map[string]interface{}{
-				"error": fmt.Sprintf("failed to unmarshal query params for http RPC request: %s", err.Error()),
-			})
-
-			err := msg.Respond(resp)
-			if err != nil {
-				h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-			}
-			return
-		}
-	}
-
-	status, resphdrs, httpresp, err := client.Get(url.Path, params)
+	status, resphdrs, httpresp, err := client.Get(url.Path, url.Query())
 	if err != nil {
 		resp, _ := json.Marshal(map[string]interface{}{
 			"error": fmt.Sprintf("http reqeust failed: %s", err.Error()),
@@ -155,23 +123,7 @@ func (h *HTTPService) handleGet(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePost(msg *nats.Msg) {
-	var req *agentapi.HostServicesHTTPRequest
-	err := json.Unmarshal(msg.Data, &req)
-	if err != nil {
-		h.log.Warn(fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	url, err := url.Parse(req.URL)
+	url, err := url.Parse(msg.Header.Get(httpURL))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -190,25 +142,7 @@ func (h *HTTPService) handlePost(msg *nats.Msg) {
 		WithLogger(h.log).
 		WithTimeoutMillis(defaultHTTPRequestTimeoutMillis)
 
-	params := map[string]interface{}{}
-	if req.Params != nil {
-		err = json.Unmarshal(*req.Params, &params)
-		if err != nil {
-			h.log.Debug("failed to unmarshal query params for http RPC request", slog.String("error", err.Error()))
-
-			resp, _ := json.Marshal(map[string]interface{}{
-				"error": fmt.Sprintf("failed to unmarshal query params for http RPC request: %s", err.Error()),
-			})
-
-			err := msg.Respond(resp)
-			if err != nil {
-				h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-			}
-			return
-		}
-	}
-
-	status, resphdrs, httpresp, err := client.Post(url.Path, req.Body)
+	status, resphdrs, httpresp, err := client.Post(url.Path, msg.Data)
 	if err != nil {
 		resp, _ := json.Marshal(map[string]interface{}{
 			"error": fmt.Sprintf("http reqeust failed: %s", err.Error()),
@@ -236,23 +170,7 @@ func (h *HTTPService) handlePost(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePut(msg *nats.Msg) {
-	var req *agentapi.HostServicesHTTPRequest
-	err := json.Unmarshal(msg.Data, &req)
-	if err != nil {
-		h.log.Warn(fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	url, err := url.Parse(req.URL)
+	url, err := url.Parse(msg.Header.Get(httpURL))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -271,25 +189,7 @@ func (h *HTTPService) handlePut(msg *nats.Msg) {
 		WithLogger(h.log).
 		WithTimeoutMillis(defaultHTTPRequestTimeoutMillis)
 
-	params := map[string]interface{}{}
-	if req.Params != nil {
-		err = json.Unmarshal(*req.Params, &params)
-		if err != nil {
-			h.log.Debug("failed to unmarshal query params for http RPC request", slog.String("error", err.Error()))
-
-			resp, _ := json.Marshal(map[string]interface{}{
-				"error": fmt.Sprintf("failed to unmarshal query params for http RPC request: %s", err.Error()),
-			})
-
-			err := msg.Respond(resp)
-			if err != nil {
-				h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-			}
-			return
-		}
-	}
-
-	status, resphdrs, httpresp, err := client.Put(url.Path, req.Body)
+	status, resphdrs, httpresp, err := client.Put(url.Path, msg.Data)
 	if err != nil {
 		resp, _ := json.Marshal(map[string]interface{}{
 			"error": fmt.Sprintf("http reqeust failed: %s", err.Error()),
@@ -317,23 +217,7 @@ func (h *HTTPService) handlePut(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePatch(msg *nats.Msg) {
-	var req *agentapi.HostServicesHTTPRequest
-	err := json.Unmarshal(msg.Data, &req)
-	if err != nil {
-		h.log.Warn(fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	url, err := url.Parse(req.URL)
+	url, err := url.Parse(msg.Header.Get(httpURL))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -352,25 +236,7 @@ func (h *HTTPService) handlePatch(msg *nats.Msg) {
 		WithLogger(h.log).
 		WithTimeoutMillis(defaultHTTPRequestTimeoutMillis)
 
-	params := map[string]interface{}{}
-	if req.Params != nil {
-		err = json.Unmarshal(*req.Params, &params)
-		if err != nil {
-			h.log.Debug("failed to unmarshal query params for http RPC request", slog.String("error", err.Error()))
-
-			resp, _ := json.Marshal(map[string]interface{}{
-				"error": fmt.Sprintf("failed to unmarshal query params for http RPC request: %s", err.Error()),
-			})
-
-			err := msg.Respond(resp)
-			if err != nil {
-				h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-			}
-			return
-		}
-	}
-
-	status, resphdrs, httpresp, err := client.Patch(url.Path, req.Body)
+	status, resphdrs, httpresp, err := client.Patch(url.Path, msg.Data)
 	if err != nil {
 		resp, _ := json.Marshal(map[string]interface{}{
 			"error": fmt.Sprintf("http reqeust failed: %s", err.Error()),
@@ -398,23 +264,7 @@ func (h *HTTPService) handlePatch(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleDelete(msg *nats.Msg) {
-	var req *agentapi.HostServicesHTTPRequest
-	err := json.Unmarshal(msg.Data, &req)
-	if err != nil {
-		h.log.Warn(fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	url, err := url.Parse(req.URL)
+	url, err := url.Parse(msg.Header.Get(httpURL))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -432,24 +282,6 @@ func (h *HTTPService) handleDelete(msg *nats.Msg) {
 	client := util.NewHTTPClient(url.Scheme, url.Host, "").
 		WithLogger(h.log).
 		WithTimeoutMillis(defaultHTTPRequestTimeoutMillis)
-
-	params := map[string]interface{}{}
-	if req.Params != nil {
-		err = json.Unmarshal(*req.Params, &params)
-		if err != nil {
-			h.log.Debug("failed to unmarshal query params for http RPC request", slog.String("error", err.Error()))
-
-			resp, _ := json.Marshal(map[string]interface{}{
-				"error": fmt.Sprintf("failed to unmarshal query params for http RPC request: %s", err.Error()),
-			})
-
-			err := msg.Respond(resp)
-			if err != nil {
-				h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-			}
-			return
-		}
-	}
 
 	status, resphdrs, httpresp, err := client.Delete(url.Path)
 	if err != nil {
@@ -479,23 +311,7 @@ func (h *HTTPService) handleDelete(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleHead(msg *nats.Msg) {
-	var req *agentapi.HostServicesHTTPRequest
-	err := json.Unmarshal(msg.Data, &req)
-	if err != nil {
-		h.log.Warn(fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal http RPC request: %s", err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	url, err := url.Parse(req.URL)
+	url, err := url.Parse(msg.Header.Get(httpURL))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -514,25 +330,7 @@ func (h *HTTPService) handleHead(msg *nats.Msg) {
 		WithLogger(h.log).
 		WithTimeoutMillis(defaultHTTPRequestTimeoutMillis)
 
-	params := map[string]interface{}{}
-	if req.Params != nil {
-		err = json.Unmarshal(*req.Params, &params)
-		if err != nil {
-			h.log.Debug("failed to unmarshal query params for http RPC request", slog.String("error", err.Error()))
-
-			resp, _ := json.Marshal(map[string]interface{}{
-				"error": fmt.Sprintf("failed to unmarshal query params for http RPC request: %s", err.Error()),
-			})
-
-			err := msg.Respond(resp)
-			if err != nil {
-				h.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-			}
-			return
-		}
-	}
-
-	status, resphdrs, err := client.Head(url.Path, params)
+	status, resphdrs, err := client.Head(url.Path, url.Query())
 	if err != nil {
 		resp, _ := json.Marshal(map[string]interface{}{
 			"error": fmt.Sprintf("http reqeust failed: %s", err.Error()),

--- a/internal/node/services/lib/http.go
+++ b/internal/node/services/lib/http.go
@@ -21,8 +21,6 @@ const httpServiceMethodHead = "head"
 
 const defaultHTTPRequestTimeoutMillis = 2500
 
-const httpURLHeader = "x-http-url"
-
 type HTTPService struct {
 	log *slog.Logger
 	nc  *nats.Conn
@@ -76,7 +74,7 @@ func (h *HTTPService) HandleRPC(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleGet(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURLHeader))
+	url, err := url.Parse(msg.Header.Get(agentapi.HttpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -123,7 +121,7 @@ func (h *HTTPService) handleGet(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePost(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURLHeader))
+	url, err := url.Parse(msg.Header.Get(agentapi.HttpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -170,7 +168,7 @@ func (h *HTTPService) handlePost(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePut(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURLHeader))
+	url, err := url.Parse(msg.Header.Get(agentapi.HttpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -217,7 +215,7 @@ func (h *HTTPService) handlePut(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePatch(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURLHeader))
+	url, err := url.Parse(msg.Header.Get(agentapi.HttpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -264,7 +262,7 @@ func (h *HTTPService) handlePatch(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleDelete(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURLHeader))
+	url, err := url.Parse(msg.Header.Get(agentapi.HttpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -311,7 +309,7 @@ func (h *HTTPService) handleDelete(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleHead(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURLHeader))
+	url, err := url.Parse(msg.Header.Get(agentapi.HttpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 

--- a/internal/node/services/lib/http.go
+++ b/internal/node/services/lib/http.go
@@ -21,7 +21,7 @@ const httpServiceMethodHead = "head"
 
 const defaultHTTPRequestTimeoutMillis = 2500
 
-const httpURL = "x-http-url"
+const httpURLHeader = "x-http-url"
 
 type HTTPService struct {
 	log *slog.Logger
@@ -76,7 +76,7 @@ func (h *HTTPService) HandleRPC(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleGet(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURL))
+	url, err := url.Parse(msg.Header.Get(httpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -123,7 +123,7 @@ func (h *HTTPService) handleGet(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePost(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURL))
+	url, err := url.Parse(msg.Header.Get(httpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -170,7 +170,7 @@ func (h *HTTPService) handlePost(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePut(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURL))
+	url, err := url.Parse(msg.Header.Get(httpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -217,7 +217,7 @@ func (h *HTTPService) handlePut(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handlePatch(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURL))
+	url, err := url.Parse(msg.Header.Get(httpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -264,7 +264,7 @@ func (h *HTTPService) handlePatch(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleDelete(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURL))
+	url, err := url.Parse(msg.Header.Get(httpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 
@@ -311,7 +311,7 @@ func (h *HTTPService) handleDelete(msg *nats.Msg) {
 }
 
 func (h *HTTPService) handleHead(msg *nats.Msg) {
-	url, err := url.Parse(msg.Header.Get(httpURL))
+	url, err := url.Parse(msg.Header.Get(httpURLHeader))
 	if err != nil {
 		h.log.Debug("failed to parse url for http RPC request", slog.String("error", err.Error()))
 

--- a/internal/node/services/lib/keyvalue.go
+++ b/internal/node/services/lib/keyvalue.go
@@ -16,8 +16,6 @@ const kvServiceMethodSet = "set"
 const kvServiceMethodDelete = "delete"
 const kvServiceMethodKeys = "keys"
 
-const keyValueKeyHeader = "x-key"
-
 type KeyValueService struct {
 	log *slog.Logger
 	nc  *nats.Conn
@@ -76,7 +74,7 @@ func (k *KeyValueService) handleGet(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	key := msg.Header.Get(keyValueKeyHeader)
+	key := msg.Header.Get(agentapi.KeyValueKeyHeader)
 	if key == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
 			Errors: []string{"key is required"},
@@ -120,7 +118,7 @@ func (k *KeyValueService) handleSet(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	key := msg.Header.Get(keyValueKeyHeader)
+	key := msg.Header.Get(agentapi.KeyValueKeyHeader)
 	if key == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
 			Errors: []string{"key is required"},
@@ -168,7 +166,7 @@ func (k *KeyValueService) handleDelete(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	key := msg.Header.Get(keyValueKeyHeader)
+	key := msg.Header.Get(agentapi.KeyValueKeyHeader)
 	if key == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
 			Errors: []string{"key is required"},

--- a/internal/node/services/lib/keyvalue.go
+++ b/internal/node/services/lib/keyvalue.go
@@ -16,7 +16,7 @@ const kvServiceMethodSet = "set"
 const kvServiceMethodDelete = "delete"
 const kvServiceMethodKeys = "keys"
 
-const keyHeader = "x-key"
+const keyValueKeyHeader = "x-key"
 
 type KeyValueService struct {
 	log *slog.Logger
@@ -76,7 +76,7 @@ func (k *KeyValueService) handleGet(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	key := msg.Header.Get(keyHeader)
+	key := msg.Header.Get(keyValueKeyHeader)
 	if key == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
 			Errors: []string{"key is required"},
@@ -120,7 +120,7 @@ func (k *KeyValueService) handleSet(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	key := msg.Header.Get(keyHeader)
+	key := msg.Header.Get(keyValueKeyHeader)
 	if key == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
 			Errors: []string{"key is required"},
@@ -168,7 +168,7 @@ func (k *KeyValueService) handleDelete(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	key := msg.Header.Get(keyHeader)
+	key := msg.Header.Get(keyValueKeyHeader)
 	if key == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
 			Errors: []string{"key is required"},

--- a/internal/node/services/lib/keyvalue.go
+++ b/internal/node/services/lib/keyvalue.go
@@ -16,6 +16,8 @@ const kvServiceMethodSet = "set"
 const kvServiceMethodDelete = "delete"
 const kvServiceMethodKeys = "keys"
 
+const keyHeader = "x-key"
+
 type KeyValueService struct {
 	log *slog.Logger
 	nc  *nats.Conn
@@ -74,13 +76,25 @@ func (k *KeyValueService) handleGet(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	var req *agentapi.HostServicesKeyValueRequest
-	err = json.Unmarshal(msg.Data, &req)
+	key := msg.Header.Get(keyHeader)
+	if key == "" {
+		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
+			Errors: []string{"key is required"},
+		})
+
+		err := msg.Respond(resp)
+		if err != nil {
+			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
+		}
+		return
+	}
+
+	entry, err := kvStore.Get(key)
 	if err != nil {
-		k.log.Warn(fmt.Sprintf("failed to unmarshal key/value RPC request: %s", err.Error()))
+		k.log.Warn(fmt.Sprintf("failed to get value for key %s: %s", key, err.Error()))
 
 		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal key/value RPC request: %s", err.Error()),
+			"error": fmt.Sprintf("failed to get value for key %s: %s", key, err.Error()),
 		})
 
 		err := msg.Respond(resp)
@@ -90,39 +104,7 @@ func (k *KeyValueService) handleGet(msg *nats.Msg) {
 		return
 	}
 
-	if req.Key == nil {
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": "key is required",
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	entry, err := kvStore.Get(*req.Key)
-	if err != nil {
-		k.log.Warn(fmt.Sprintf("failed to get value for key %s: %s", *req.Key, err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to delete keys %s: %s", *req.Key, err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	val := json.RawMessage(entry.Value())
-	resp, _ := json.Marshal(&agentapi.HostServicesKeyValueRequest{
-		Key:   req.Key,
-		Value: &val,
-	})
-	err = msg.Respond(resp)
+	err = msg.Respond(entry.Value())
 	if err != nil {
 		k.log.Warn(fmt.Sprintf("failed to respond to key/value host service request: %s", err.Error()))
 	}
@@ -138,54 +120,25 @@ func (k *KeyValueService) handleSet(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	var req *agentapi.HostServicesKeyValueRequest
-	err = json.Unmarshal(msg.Data, &req)
+	key := msg.Header.Get(keyHeader)
+	if key == "" {
+		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
+			Errors: []string{"key is required"},
+		})
+
+		err := msg.Respond(resp)
+		if err != nil {
+			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
+		}
+		return
+	}
+
+	revision, err := kvStore.Put(key, msg.Data)
 	if err != nil {
-		k.log.Warn(fmt.Sprintf("failed to unmarshal key/value RPC request: %s", err.Error()))
+		k.log.Warn(fmt.Sprintf("failed to write %d-byte value for key %s: %s", len(msg.Data), key, err.Error()))
 
 		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal key/value RPC request: %s", err.Error()),
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	// FIXME-- add req.Validate()
-	if req.Key == nil {
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": "key is required",
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	// FIXME-- add req.Validate()
-	if req.Value == nil {
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": "value is required",
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	revision, err := kvStore.Put(*req.Key, *req.Value)
-	if err != nil {
-		k.log.Warn(fmt.Sprintf("failed to write %d-byte value for key %s: %s", len(*req.Value), *req.Key, err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to write %d-byte value for key %s: %s", len(*req.Value), *req.Key, err.Error()),
+			"error": fmt.Sprintf("failed to write %d-byte value for key %s: %s", len(msg.Data), key, err.Error()),
 		})
 
 		err := msg.Respond(resp)
@@ -215,13 +168,10 @@ func (k *KeyValueService) handleDelete(msg *nats.Msg) {
 		k.log.Warn(fmt.Sprintf("failed to resolve key/value store: %s", err.Error()))
 	}
 
-	var req *agentapi.HostServicesKeyValueRequest
-	err = json.Unmarshal(msg.Data, &req)
-	if err != nil {
-		k.log.Warn(fmt.Sprintf("failed to unmarshal key/value RPC request: %s", err.Error()))
-
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to unmarshal key/value RPC request: %s", err.Error()),
+	key := msg.Header.Get(keyHeader)
+	if key == "" {
+		resp, _ := json.Marshal(&agentapi.HostServicesKeyValueResponse{
+			Errors: []string{"key is required"},
 		})
 
 		err := msg.Respond(resp)
@@ -231,24 +181,12 @@ func (k *KeyValueService) handleDelete(msg *nats.Msg) {
 		return
 	}
 
-	if req.Key == nil {
-		resp, _ := json.Marshal(map[string]interface{}{
-			"error": "key is required",
-		})
-
-		err := msg.Respond(resp)
-		if err != nil {
-			k.log.Error(fmt.Sprintf("failed to respond to host services RPC request: %s", err.Error()))
-		}
-		return
-	}
-
-	err = kvStore.Delete(*req.Key)
+	err = kvStore.Delete(key)
 	if err != nil {
-		k.log.Warn(fmt.Sprintf("failed to delete key %s: %s", *req.Key, err.Error()))
+		k.log.Warn(fmt.Sprintf("failed to delete key %s: %s", key, err.Error()))
 
 		resp, _ := json.Marshal(map[string]interface{}{
-			"error": fmt.Sprintf("failed to delete keys %s: %s", *req.Key, err.Error()),
+			"error": fmt.Sprintf("failed to delete key %s: %s", key, err.Error()),
 		})
 
 		err := msg.Respond(resp)

--- a/internal/node/services/lib/messaging.go
+++ b/internal/node/services/lib/messaging.go
@@ -19,7 +19,7 @@ const messagingServiceMethodRequestMany = "requestMany"
 const messagingRequestTimeout = time.Millisecond * 500 // FIXME-- make timeout configurable per request?
 const messagingRequestManyTimeout = time.Millisecond * 3000
 
-const messageSubject = "x-subject"
+const messagingSubjectHeader = "x-subject"
 
 type MessagingService struct {
 	log *slog.Logger
@@ -66,7 +66,7 @@ func (m *MessagingService) HandleRPC(msg *nats.Msg) {
 }
 
 func (m *MessagingService) handlePublish(msg *nats.Msg) {
-	subject := msg.Header.Get(messageSubject)
+	subject := msg.Header.Get(messagingSubjectHeader)
 	if subject == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesMessagingResponse{
 			Errors: []string{"subject is required"},
@@ -104,7 +104,7 @@ func (m *MessagingService) handlePublish(msg *nats.Msg) {
 }
 
 func (m *MessagingService) handleRequest(msg *nats.Msg) {
-	subject := msg.Header.Get(messageSubject)
+	subject := msg.Header.Get(messagingSubjectHeader)
 	if subject == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesMessagingResponse{
 			Errors: []string{"subject is required"},
@@ -141,7 +141,7 @@ func (m *MessagingService) handleRequest(msg *nats.Msg) {
 }
 
 func (m *MessagingService) handleRequestMany(msg *nats.Msg) {
-	subject := msg.Header.Get(messageSubject)
+	subject := msg.Header.Get(messagingSubjectHeader)
 	if subject == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesMessagingResponse{
 			Errors: []string{"subject is required"},

--- a/internal/node/services/lib/messaging.go
+++ b/internal/node/services/lib/messaging.go
@@ -19,8 +19,6 @@ const messagingServiceMethodRequestMany = "requestMany"
 const messagingRequestTimeout = time.Millisecond * 500 // FIXME-- make timeout configurable per request?
 const messagingRequestManyTimeout = time.Millisecond * 3000
 
-const messagingSubjectHeader = "x-subject"
-
 type MessagingService struct {
 	log *slog.Logger
 	nc  *nats.Conn
@@ -66,7 +64,7 @@ func (m *MessagingService) HandleRPC(msg *nats.Msg) {
 }
 
 func (m *MessagingService) handlePublish(msg *nats.Msg) {
-	subject := msg.Header.Get(messagingSubjectHeader)
+	subject := msg.Header.Get(agentapi.MessagingSubjectHeader)
 	if subject == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesMessagingResponse{
 			Errors: []string{"subject is required"},
@@ -104,7 +102,7 @@ func (m *MessagingService) handlePublish(msg *nats.Msg) {
 }
 
 func (m *MessagingService) handleRequest(msg *nats.Msg) {
-	subject := msg.Header.Get(messagingSubjectHeader)
+	subject := msg.Header.Get(agentapi.MessagingSubjectHeader)
 	if subject == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesMessagingResponse{
 			Errors: []string{"subject is required"},
@@ -141,7 +139,7 @@ func (m *MessagingService) handleRequest(msg *nats.Msg) {
 }
 
 func (m *MessagingService) handleRequestMany(msg *nats.Msg) {
-	subject := msg.Header.Get(messagingSubjectHeader)
+	subject := msg.Header.Get(agentapi.MessagingSubjectHeader)
 	if subject == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesMessagingResponse{
 			Errors: []string{"subject is required"},

--- a/internal/node/services/lib/objectstore.go
+++ b/internal/node/services/lib/objectstore.go
@@ -19,7 +19,7 @@ const objectStoreServiceMethodPut = "put"
 const objectStoreServiceMethodDelete = "delete"
 const objectStoreServiceMethodList = "list"
 
-const objectName = "x-object-name"
+const objectStoreObjectNameHeader = "x-object-name"
 
 type ObjectStoreService struct {
 	log *slog.Logger
@@ -79,7 +79,7 @@ func (o *ObjectStoreService) handleGet(msg *nats.Msg) {
 		o.log.Warn(fmt.Sprintf("failed to resolve object store: %s", err.Error()))
 	}
 
-	name := msg.Header.Get(objectName)
+	name := msg.Header.Get(objectStoreObjectNameHeader)
 	if name == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesObjectStoreResponse{
 			Errors: []string{"name is required"},
@@ -138,7 +138,7 @@ func (o *ObjectStoreService) handlePut(msg *nats.Msg) {
 		o.log.Warn(fmt.Sprintf("failed to resolve object store: %s", err.Error()))
 	}
 
-	name := msg.Header.Get(objectName)
+	name := msg.Header.Get(objectStoreObjectNameHeader)
 	if name == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesObjectStoreResponse{
 			Errors: []string{"name is required"},
@@ -190,7 +190,7 @@ func (o *ObjectStoreService) handleDelete(msg *nats.Msg) {
 		o.log.Warn(fmt.Sprintf("failed to resolve object store: %s", err.Error()))
 	}
 
-	name := msg.Header.Get(objectName)
+	name := msg.Header.Get(objectStoreObjectNameHeader)
 	if name == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesObjectStoreResponse{
 			Errors: []string{"name is required"},

--- a/internal/node/services/lib/objectstore.go
+++ b/internal/node/services/lib/objectstore.go
@@ -19,8 +19,6 @@ const objectStoreServiceMethodPut = "put"
 const objectStoreServiceMethodDelete = "delete"
 const objectStoreServiceMethodList = "list"
 
-const objectStoreObjectNameHeader = "x-object-name"
-
 type ObjectStoreService struct {
 	log *slog.Logger
 	nc  *nats.Conn
@@ -79,7 +77,7 @@ func (o *ObjectStoreService) handleGet(msg *nats.Msg) {
 		o.log.Warn(fmt.Sprintf("failed to resolve object store: %s", err.Error()))
 	}
 
-	name := msg.Header.Get(objectStoreObjectNameHeader)
+	name := msg.Header.Get(agentapi.ObjectStoreObjectNameHeader)
 	if name == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesObjectStoreResponse{
 			Errors: []string{"name is required"},
@@ -138,7 +136,7 @@ func (o *ObjectStoreService) handlePut(msg *nats.Msg) {
 		o.log.Warn(fmt.Sprintf("failed to resolve object store: %s", err.Error()))
 	}
 
-	name := msg.Header.Get(objectStoreObjectNameHeader)
+	name := msg.Header.Get(agentapi.ObjectStoreObjectNameHeader)
 	if name == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesObjectStoreResponse{
 			Errors: []string{"name is required"},
@@ -190,7 +188,7 @@ func (o *ObjectStoreService) handleDelete(msg *nats.Msg) {
 		o.log.Warn(fmt.Sprintf("failed to resolve object store: %s", err.Error()))
 	}
 
-	name := msg.Header.Get(objectStoreObjectNameHeader)
+	name := msg.Header.Get(agentapi.ObjectStoreObjectNameHeader)
 	if name == "" {
 		resp, _ := json.Marshal(&agentapi.HostServicesObjectStoreResponse{
 			Errors: []string{"name is required"},

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -33,8 +33,6 @@ const (
 	WorkloadCacheBucketName = "NEXCACHE"
 
 	defaultHandshakeTimeoutMillis = 5000
-
-	nexRuntimeNs = "x-nex-runtime-ns"
 )
 
 // The workload manager provides the high level strategy for the Nex node's workload management. It is responsible
@@ -484,7 +482,7 @@ func (w *WorkloadManager) generateTriggerHandler(workloadID string, tsub string,
 			_ = w.publishFunctionExecFailed(workloadID, *request.WorkloadName, tsub, err)
 		} else if resp != nil {
 			parentSpan.SetStatus(codes.Ok, "Trigger succeeded")
-			runtimeNs := resp.Header.Get(nexRuntimeNs)
+			runtimeNs := resp.Header.Get(agentapi.NexRuntimeNs)
 			w.log.Debug("Received response from execution via trigger subject",
 				slog.String("workload_id", workloadID),
 				slog.String("trigger_subject", tsub),

--- a/spec/node_test.go
+++ b/spec/node_test.go
@@ -581,7 +581,7 @@ var _ = Describe("nex node", func() {
 
 													type hostServicesExampleResp struct {
 														Keys   []string `json:"keys"`
-														Hello2 string   `json:"hello2"`
+														Hello2 []uint8  `json:"hello2"`
 													}
 
 													var resp *hostServicesExampleResp
@@ -592,7 +592,7 @@ var _ = Describe("nex node", func() {
 
 													Expect(len(resp.Keys)).To(Equal(1))
 													Expect(resp.Keys[0]).To(Equal("hello2"))
-													Expect(resp.Hello2).To(Equal("hello!"))
+													Expect(resp.Hello2).To(BeEquivalentTo("hello!"))
 												})
 											})
 										})
@@ -645,8 +645,8 @@ var _ = Describe("nex node", func() {
 													Expect(respmsg).NotTo(BeNil())
 
 													type hostServicesExampleResp struct {
-														HelloWorldRequest     string   `json:"hello.world.request"`
-														HelloWorldRequestMany []string `json:"hello.world.request.many"`
+														HelloWorldRequest     []uint8   `json:"hello.world.request"`
+														HelloWorldRequestMany [][]uint8 `json:"hello.world.request.many"`
 													}
 
 													var resp *hostServicesExampleResp
@@ -656,15 +656,15 @@ var _ = Describe("nex node", func() {
 													Expect(resp).ToNot(BeNil())
 
 													Expect(resp.HelloWorldRequest).ToNot(BeNil())
-													Expect(resp.HelloWorldRequest).To(Equal("resp: asdfghjkl;'"))
+													Expect(resp.HelloWorldRequest).To(BeEquivalentTo("resp: asdfghjkl;'"))
 												})
 
 												It("should respond to the request with the hello.world.request.many response values", func(ctx SpecContext) {
 													Expect(respmsg).NotTo(BeNil())
 
 													type hostServicesExampleResp struct {
-														HelloWorldRequest     string   `json:"hello.world.request"`
-														HelloWorldRequestMany []string `json:"hello.world.request.many"`
+														HelloWorldRequest     []uint8   `json:"hello.world.request"`
+														HelloWorldRequestMany [][]uint8 `json:"hello.world.request.many"`
 													}
 
 													var resp *hostServicesExampleResp
@@ -675,8 +675,8 @@ var _ = Describe("nex node", func() {
 
 													Expect(resp.HelloWorldRequestMany).ToNot(BeNil())
 													Expect(len(resp.HelloWorldRequestMany)).To(Equal(2))
-													Expect(resp.HelloWorldRequestMany[0]).To(Equal("resp #1: asdfghjkl;'"))
-													Expect(resp.HelloWorldRequestMany[1]).To(Equal("resp #2: asdfghjkl;'"))
+													Expect(resp.HelloWorldRequestMany[0]).To(BeEquivalentTo("resp #1: asdfghjkl;'"))
+													Expect(resp.HelloWorldRequestMany[1]).To(BeEquivalentTo("resp #2: asdfghjkl;'"))
 												})
 											})
 										})
@@ -840,7 +840,7 @@ var _ = Describe("nex node", func() {
 													Expect(respmsg).NotTo(BeNil())
 
 													type hostServicesExampleResp struct {
-														Hello2 string             `json:"hello2"`
+														Hello2 []uint8            `json:"hello2"`
 														List   []*nats.ObjectInfo `json:"list"`
 													}
 
@@ -850,11 +850,9 @@ var _ = Describe("nex node", func() {
 
 													Expect(resp).ToNot(BeNil())
 
-													fmt.Printf("IN TEST NAME: %s; NUID: %s", resp.List[0].Name, resp.List[0].NUID)
-
 													Expect(len(resp.List)).To(Equal(1))
 													Expect(resp.List[0].Name).To(Equal("hello2"))
-													Expect(resp.Hello2).To(Equal("hello!"))
+													Expect(resp.Hello2).To(BeEquivalentTo("hello!"))
 												})
 											})
 										})

--- a/spec/node_test.go
+++ b/spec/node_test.go
@@ -547,7 +547,7 @@ var _ = Describe("nex node", func() {
 
 											It("should respond to the request by echoing the payload", func(ctx SpecContext) {
 												Expect(respmsg).NotTo(BeNil())
-												Expect(respmsg.Data).To(Equal([]byte(fmt.Sprintf("{\"triggered_on\":\"%s\",\"payload\":\"hello world\"}", triggerSubject))))
+												Expect(respmsg.Data).To(Equal([]byte(fmt.Sprintf("{\"triggered_on\":\"%s\",\"payload\":[104,101,108,108,111,32,119,111,114,108,100]}", triggerSubject))))
 											})
 										})
 									})
@@ -581,7 +581,7 @@ var _ = Describe("nex node", func() {
 
 													type hostServicesExampleResp struct {
 														Keys   []string `json:"keys"`
-														Hello2 []uint8  `json:"hello2"`
+														Hello2 string   `json:"hello2"`
 													}
 
 													var resp *hostServicesExampleResp
@@ -592,7 +592,7 @@ var _ = Describe("nex node", func() {
 
 													Expect(len(resp.Keys)).To(Equal(1))
 													Expect(resp.Keys[0]).To(Equal("hello2"))
-													Expect(resp.Hello2).To(BeEquivalentTo("hello!"))
+													Expect(resp.Hello2).To(Equal("hello!"))
 												})
 											})
 										})
@@ -618,15 +618,15 @@ var _ = Describe("nex node", func() {
 
 												BeforeEach(func() {
 													sub, _ = _fixtures.natsConn.Subscribe("hello.world.request", func(msg *nats.Msg) {
-														resp := fmt.Sprintf("resp: %s", string(msg.Data))
+														resp := fmt.Sprintf("resp: %s", msg.Data)
 														_ = msg.Respond([]byte(resp))
 													})
 
 													sub, _ = _fixtures.natsConn.Subscribe("hello.world.request.many", func(msg *nats.Msg) {
-														resp := fmt.Sprintf("resp #1: %s", string(msg.Data))
+														resp := fmt.Sprintf("resp #1: %s", msg.Data)
 														_ = msg.Respond([]byte(resp))
 
-														resp = fmt.Sprintf("resp #2: %s", string(msg.Data))
+														resp = fmt.Sprintf("resp #2: %s", msg.Data)
 														_ = msg.Respond([]byte(resp))
 													})
 												})
@@ -645,8 +645,8 @@ var _ = Describe("nex node", func() {
 													Expect(respmsg).NotTo(BeNil())
 
 													type hostServicesExampleResp struct {
-														HelloWorldRequest     []uint8   `json:"hello.world.request"`
-														HelloWorldRequestMany [][]uint8 `json:"hello.world.request.many"`
+														HelloWorldRequest     string   `json:"hello.world.request"`
+														HelloWorldRequestMany []string `json:"hello.world.request.many"`
 													}
 
 													var resp *hostServicesExampleResp
@@ -656,15 +656,15 @@ var _ = Describe("nex node", func() {
 													Expect(resp).ToNot(BeNil())
 
 													Expect(resp.HelloWorldRequest).ToNot(BeNil())
-													Expect(resp.HelloWorldRequest).To(BeEquivalentTo("resp: asdfghjkl;'"))
+													Expect(resp.HelloWorldRequest).To(Equal("resp: asdfghjkl;'"))
 												})
 
 												It("should respond to the request with the hello.world.request.many response values", func(ctx SpecContext) {
 													Expect(respmsg).NotTo(BeNil())
 
 													type hostServicesExampleResp struct {
-														HelloWorldRequest     []uint8   `json:"hello.world.request"`
-														HelloWorldRequestMany [][]uint8 `json:"hello.world.request.many"`
+														HelloWorldRequest     string   `json:"hello.world.request"`
+														HelloWorldRequestMany []string `json:"hello.world.request.many"`
 													}
 
 													var resp *hostServicesExampleResp
@@ -675,8 +675,8 @@ var _ = Describe("nex node", func() {
 
 													Expect(resp.HelloWorldRequestMany).ToNot(BeNil())
 													Expect(len(resp.HelloWorldRequestMany)).To(Equal(2))
-													Expect(resp.HelloWorldRequestMany[0]).To(BeEquivalentTo("resp #1: asdfghjkl;'"))
-													Expect(resp.HelloWorldRequestMany[1]).To(BeEquivalentTo("resp #2: asdfghjkl;'"))
+													Expect(resp.HelloWorldRequestMany[0]).To(Equal("resp #1: asdfghjkl;'"))
+													Expect(resp.HelloWorldRequestMany[1]).To(Equal("resp #2: asdfghjkl;'"))
 												})
 											})
 										})
@@ -840,7 +840,7 @@ var _ = Describe("nex node", func() {
 													Expect(respmsg).NotTo(BeNil())
 
 													type hostServicesExampleResp struct {
-														Hello2 []uint8            `json:"hello2"`
+														Hello2 string             `json:"hello2"`
 														List   []*nats.ObjectInfo `json:"list"`
 													}
 
@@ -852,7 +852,7 @@ var _ = Describe("nex node", func() {
 
 													Expect(len(resp.List)).To(Equal(1))
 													Expect(resp.List[0].Name).To(Equal("hello2"))
-													Expect(resp.Hello2).To(BeEquivalentTo("hello!"))
+													Expect(resp.Hello2).To(Equal("hello!"))
 												})
 											})
 										})

--- a/spec/node_test.go
+++ b/spec/node_test.go
@@ -547,7 +547,7 @@ var _ = Describe("nex node", func() {
 
 											It("should respond to the request by echoing the payload", func(ctx SpecContext) {
 												Expect(respmsg).NotTo(BeNil())
-												Expect(respmsg.Data).To(Equal([]byte(fmt.Sprintf("{\"triggered_on\":\"%s\",\"payload\":[104,101,108,108,111,32,119,111,114,108,100]}", triggerSubject))))
+												Expect(respmsg.Data).To(Equal([]byte(fmt.Sprintf("{\"triggered_on\":\"%s\",\"payload\":\"hello world\"}", triggerSubject))))
 											})
 										})
 									})


### PR DESCRIPTION
This PR cleans up the v8 host services provider implementation.

The agent v8 provider now exclusively requires and uses `Uint8Array` when:
- marshaling parameters included in functions called from javascript (`v8.Value` -> `[]byte`)
- unmarshaling raw bytes returned to functions called from javascript (`[]byte` -> `v8.Value`)

Additionally, the host services API has been cleaned up in preparation for formalizing an SDK (#170). Namely, the use of message headers and non-enveloped payloads have been made consistent across host services.