### PR TITLE
Add support for starting a userland NATS server

### DIFF
--- a/examples/nodeconfigs/public_nats_server.json
+++ b/examples/nodeconfigs/public_nats_server.json
@@ -1,0 +1,22 @@
+{
+    "kernel_filepath": "/path/to/vmlinux-5.10",
+    "rootfs_filepath": "/path/to/rootfs.ext4",
+    "machine_pool_size": 1,
+    "cni": {
+        "network_name": "fcnet",
+        "interface_name": "veth0"
+    },
+    "machine_template": {
+        "vcpu_count": 1,
+        "memsize_mib": 256
+    },
+    "public_nats_server": {
+        "server_name": "Nex Public NATS Server",
+        "addr": "0.0.0.0",
+        "port": 4222,
+        "jetstream": true
+    },
+    "tags": {
+        "simple": "true"
+    }
+}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -59,7 +59,7 @@ type NodeConfiguration struct {
 	WorkloadTypes       []string          `json:"workload_types,omitempty"`
 
 	// Public NATS server options; when non-nil, a public "userland" NATS server is started during node init
-	PublicNATSServer *server.Options `json:"public_nats_options,omitempty"`
+	PublicNATSServer *server.Options `json:"public_nats_server,omitempty"`
 
 	Errors []error `json:"errors,omitempty"`
 }

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/splode/fname"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
@@ -44,6 +45,7 @@ type NodeConfiguration struct {
 	MachinePoolSize     int               `json:"machine_pool_size"`
 	MachineTemplate     MachineTemplate   `json:"machine_template"`
 	NoSandbox           bool              `json:"no_sandbox,omitempty"`
+	OtlpExporterUrl     string            `json:"otlp_exporter_url,omitempty"`
 	OtelMetrics         bool              `json:"otel_metrics"`
 	OtelMetricsPort     int               `json:"otel_metrics_port"`
 	OtelMetricsExporter string            `json:"otel_metrics_exporter"`
@@ -55,7 +57,9 @@ type NodeConfiguration struct {
 	Tags                map[string]string `json:"tags,omitempty"`
 	ValidIssuers        []string          `json:"valid_issuers,omitempty"`
 	WorkloadTypes       []string          `json:"workload_types,omitempty"`
-	OtlpExporterUrl     string            `json:"otlp_exporter_url,omitempty"`
+
+	// Public NATS server options; when non-nil, a public "userland" NATS server is started during node init
+	PublicNATSServer *server.Options `json:"public_nats_options,omitempty"`
 
 	Errors []error `json:"errors,omitempty"`
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -485,13 +485,14 @@ func (n *Node) shutdown() {
 			time.Sleep(time.Millisecond * 25)
 		}
 
+		n.natsint.Shutdown()
+		n.natsint.WaitForShutdown()
+
 		if n.natspub != nil {
 			n.natspub.Shutdown()
 			n.natspub.WaitForShutdown()
 		}
 
-		n.natsint.Shutdown()
-		n.natsint.WaitForShutdown()
 		_ = n.telemetry.Shutdown()
 
 		_ = os.Remove(defaultPidFilepath)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -225,6 +225,7 @@ func (n *Node) init() error {
 		err = n.loadNodeConfig()
 		if err != nil {
 			n.log.Error("Failed to load node configuration file", slog.Any("err", err), slog.String("config_path", n.nodeOpts.ConfigFilepath))
+			return
 		} else {
 			n.log.Info("Loaded node configuration", slog.String("config_path", n.nodeOpts.ConfigFilepath))
 		}
@@ -232,6 +233,7 @@ func (n *Node) init() error {
 		n.telemetry, err = observability.NewTelemetry(n.ctx, n.log, n.config, n.publicKey)
 		if err != nil {
 			n.log.Error("Failed to initialize telemetry", slog.Any("err", err))
+			return
 		} else {
 			n.log.Info("Telemetry status", slog.Bool("metrics", n.config.OtelMetrics), slog.Bool("traces", n.config.OtelTraces))
 		}
@@ -241,6 +243,7 @@ func (n *Node) init() error {
 		if err != nil {
 			n.log.Error("Failed to start public NATS server", slog.Any("err", err))
 			err = fmt.Errorf("failed to start public NATS server: %s", err)
+			return
 		} else {
 			n.log.Info("Public NATS server started", slog.String("client_url", n.natspub.ClientURL()))
 		}
@@ -250,6 +253,7 @@ func (n *Node) init() error {
 		if err != nil {
 			n.log.Error("Failed to connect to NATS server", slog.Any("err", err))
 			err = fmt.Errorf("failed to connect to NATS server: %s", err)
+			return
 		} else {
 			n.log.Info("Established node NATS connection", slog.String("servers", n.opts.Servers))
 		}
@@ -259,6 +263,7 @@ func (n *Node) init() error {
 		if err != nil {
 			n.log.Error("Failed to start internal NATS server", slog.Any("err", err))
 			err = fmt.Errorf("failed to start internal NATS server: %s", err)
+			return
 		} else {
 			n.log.Info("Internal NATS server started", slog.String("client_url", n.natsint.ClientURL()))
 		}
@@ -266,6 +271,7 @@ func (n *Node) init() error {
 		n.manager, err = NewWorkloadManager(n.ctx, n.cancelF, n.keypair, n.publicKey, n.nc, n.ncint, n.config, n.log, n.telemetry)
 		if err != nil {
 			n.log.Error("Failed to initialize machine manager", slog.Any("err", err))
+			return
 		}
 
 		go n.manager.Start()
@@ -275,6 +281,7 @@ func (n *Node) init() error {
 		err = n.api.Start()
 		if err != nil {
 			n.log.Error("Failed to start API listener", slog.Any("err", err))
+			return
 		}
 
 		n.installSignalHandlers()

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -244,7 +244,7 @@ func (n *Node) init() error {
 			n.log.Error("Failed to start public NATS server", slog.Any("err", err))
 			err = fmt.Errorf("failed to start public NATS server: %s", err)
 			return
-		} else {
+		} else if n.natspub != nil {
 			n.log.Info("Public NATS server started", slog.String("client_url", n.natspub.ClientURL()))
 		}
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -25,12 +25,13 @@ import (
 )
 
 const (
-	systemNamespace      = "system"
-	defaultNatsStoreDir  = "pnats"
-	defaultPidFilepath   = "/var/run/nex.pid"
-	runloopSleepInterval = 100 * time.Millisecond
-	runloopTickInterval  = 2500 * time.Millisecond
-	heartbeatInterval    = 30 * time.Second
+	systemNamespace              = "system"
+	defaultNatsStoreDir          = "pnats"
+	defaultPidFilepath           = "/var/run/nex.pid"
+	heartbeatInterval            = 30 * time.Second
+	publicNATSServerStartTimeout = 50 * time.Millisecond
+	runloopSleepInterval         = 100 * time.Millisecond
+	runloopTickInterval          = 2500 * time.Millisecond
 )
 
 // Nex node process
@@ -343,7 +344,13 @@ func (n *Node) startPublicNATS() error {
 		return err
 	}
 
+	n.log.Debug("Starting public NATS server")
 	n.natspub.Start()
+
+	ports := n.natspub.PortsInfo(publicNATSServerStartTimeout)
+	if ports == nil {
+		return fmt.Errorf("failed to start public NATS server")
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR allows users to configure and start a "userland" NATS server when starting a node.

Error handling inside of `node.init()` was not failing fast, resulting in discarded errors. This PR includes a fix to use `errors.Join` which allows the node to gracefully abort initialization using `shutdown()` instead of panicking.

Closes #168.