### PR TITLE
Fix regression causing workload-associated resources to leak

### DIFF
--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -334,6 +334,13 @@ func (w *WorkloadManager) Stop() error {
 	if atomic.AddUint32(&w.closing, 1) == 1 {
 		w.log.Info("Workload manager stopping")
 
+		for id := range w.activeAgents {
+			err := w.StopWorkload(id, true)
+			if err != nil {
+				w.log.Warn("Failed to stop agent", slog.String("workload_id", id), slog.String("error", err.Error()))
+			}
+		}
+
 		err := w.procMan.Stop()
 		if err != nil {
 			w.log.Error("failed to stop agent process manager", slog.Any("error", err))


### PR DESCRIPTION
This PR fixes a regression caused by not calling `StopWorkload()` for each associated agent client in the workload manager.

If the workload manager has stopped a workload, attempts to stop the same workload as a side effect of handling a `workload_stopped` cloud event from the agent will fail, since that workload will no longer be resolved.