### PR TITLE
Add tracing to host services

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -19,6 +19,8 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/synadia-io/nex/agent/providers"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 const defaultAgentHandshakeTimeoutMillis = 500
@@ -343,6 +345,11 @@ func (a *Agent) handleHealthz(w http.ResponseWriter, req *http.Request) {
 
 func (a *Agent) init() error {
 	a.installSignalHandlers()
+
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
 
 	err := a.requestHandshake()
 	if err != nil {

--- a/agent/providers/api.go
+++ b/agent/providers/api.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"errors"
 
+	"github.com/nats-io/nats.go"
 	"github.com/synadia-io/nex/agent/providers/lib"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
@@ -27,7 +28,7 @@ type ExecutionProvider interface {
 	Deploy() error
 
 	// Execute a deployed function, if supported by the execution provider implementation (e.g., "v8" and "wasm" types)
-	Execute(subject string, payload []byte) ([]byte, error)
+	Execute(headers nats.Header, payload []byte) ([]byte, error)
 
 	// Undeploy a workload, giving it a chance to gracefully clean up after itself (if applicable)
 	Undeploy() error

--- a/agent/providers/api.go
+++ b/agent/providers/api.go
@@ -38,14 +38,6 @@ type ExecutionProvider interface {
 	Validate() error
 }
 
-// HACK!!! theory was otel was not returning a propagator... but this didn't help...
-// func init() {
-// 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-// 		propagation.TraceContext{},
-// 		propagation.Baggage{},
-// 	))
-// }
-
 // NewExecutionProvider initializes and returns an execution provider for a given work request
 func NewExecutionProvider(params *agentapi.ExecutionProviderParams) (ExecutionProvider, error) {
 	if params.WorkloadType == nil {

--- a/agent/providers/api.go
+++ b/agent/providers/api.go
@@ -1,9 +1,9 @@
 package providers
 
 import (
+	"context"
 	"errors"
 
-	"github.com/nats-io/nats.go"
 	"github.com/synadia-io/nex/agent/providers/lib"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
@@ -28,7 +28,7 @@ type ExecutionProvider interface {
 	Deploy() error
 
 	// Execute a deployed function, if supported by the execution provider implementation (e.g., "v8" and "wasm" types)
-	Execute(headers nats.Header, payload []byte) ([]byte, error)
+	Execute(ctx context.Context, payload []byte) ([]byte, error)
 
 	// Undeploy a workload, giving it a chance to gracefully clean up after itself (if applicable)
 	Undeploy() error
@@ -37,6 +37,14 @@ type ExecutionProvider interface {
 	// statically-linked binary or raw source code, depending on provider implementation
 	Validate() error
 }
+
+// HACK!!! theory was otel was not returning a propagator... but this didn't help...
+// func init() {
+// 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+// 		propagation.TraceContext{},
+// 		propagation.Baggage{},
+// 	))
+// }
 
 // NewExecutionProvider initializes and returns an execution provider for a given work request
 func NewExecutionProvider(params *agentapi.ExecutionProviderParams) (ExecutionProvider, error) {

--- a/agent/providers/lib/elf.go
+++ b/agent/providers/lib/elf.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"debug/elf"
 	"errors"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nats-io/nats.go"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
 
@@ -87,7 +87,7 @@ func (e *ELF) removeWorkload() {
 	_ = os.Remove(e.tmpFilename)
 }
 
-func (e *ELF) Execute(headers nats.Header, payload []byte) ([]byte, error) {
+func (e *ELF) Execute(ctx context.Context, payload []byte) ([]byte, error) {
 	return nil, errors.New("ELF execution provider does not support execution via trigger subjects")
 }
 

--- a/agent/providers/lib/elf.go
+++ b/agent/providers/lib/elf.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
 
@@ -86,7 +87,7 @@ func (e *ELF) removeWorkload() {
 	_ = os.Remove(e.tmpFilename)
 }
 
-func (e *ELF) Execute(subject string, payload []byte) ([]byte, error) {
+func (e *ELF) Execute(headers nats.Header, payload []byte) ([]byte, error) {
 	return nil, errors.New("ELF execution provider does not support execution via trigger subjects")
 }
 

--- a/agent/providers/lib/oci.go
+++ b/agent/providers/lib/oci.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"errors"
 
+	"github.com/nats-io/nats.go"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
 
@@ -14,7 +15,7 @@ func (o *OCI) Deploy() error {
 	return errors.New("oci execution provider not yet implemented")
 }
 
-func (o *OCI) Execute(subject string, payload []byte) ([]byte, error) {
+func (o *OCI) Execute(headers nats.Header, payload []byte) ([]byte, error) {
 	return nil, errors.New("oci execution provider does not support execution via trigger subjects")
 }
 

--- a/agent/providers/lib/oci.go
+++ b/agent/providers/lib/oci.go
@@ -1,9 +1,9 @@
 package lib
 
 import (
+	"context"
 	"errors"
 
-	"github.com/nats-io/nats.go"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
 
@@ -15,7 +15,7 @@ func (o *OCI) Deploy() error {
 	return errors.New("oci execution provider not yet implemented")
 }
 
-func (o *OCI) Execute(headers nats.Header, payload []byte) ([]byte, error) {
+func (o *OCI) Execute(ctx context.Context, payload []byte) ([]byte, error) {
 	return nil, errors.New("oci execution provider does not support execution via trigger subjects")
 }
 

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -100,7 +100,7 @@ func (v *V8) Deploy() error {
 	subject := fmt.Sprintf("agentint.%s.trigger", v.vmID)
 	_, err := v.nc.Subscribe(subject, func(msg *nats.Msg) {
 		ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(msg.Header))
-		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, subject) //nolint:all
+		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, msg.Subject) //nolint:all
 
 		startTime := time.Now()
 		val, err := v.Execute(ctx, msg.Data)

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -100,7 +100,7 @@ func (v *V8) Deploy() error {
 	subject := fmt.Sprintf("agentint.%s.trigger", v.vmID)
 	_, err := v.nc.Subscribe(subject, func(msg *nats.Msg) {
 		ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(msg.Header))
-		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, msg.Subject) //nolint:all
+		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, msg.Header.Get(agentapi.NexTriggerSubject)) //nolint:all
 
 		startTime := time.Now()
 		val, err := v.Execute(ctx, msg.Data)

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -108,7 +108,8 @@ func (v *V8) Deploy() error {
 		err = msg.RespondMsg(&nats.Msg{
 			Data: val,
 			Header: nats.Header{
-				agentapi.NexRuntimeNs: []string{strconv.FormatInt(runtimeNanos, 10)},
+				agentapi.NexRuntimeNs:    []string{strconv.FormatInt(runtimeNanos, 10)},
+				agentapi.OtelTraceparent: msg.Header.Values(agentapi.OtelTraceparent),
 			},
 		})
 		if err != nil {

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -100,7 +100,7 @@ func (v *V8) Deploy() error {
 	subject := fmt.Sprintf("agentint.%s.trigger", v.vmID)
 	_, err := v.nc.Subscribe(subject, func(msg *nats.Msg) {
 		ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(msg.Header))
-		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, subject)
+		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, subject) //nolint:all
 
 		startTime := time.Now()
 		val, err := v.Execute(ctx, msg.Data)

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -99,8 +99,8 @@ func (v *V8) Deploy() error {
 
 	subject := fmt.Sprintf("agentint.%s.trigger", v.vmID)
 	_, err := v.nc.Subscribe(subject, func(msg *nats.Msg) {
-		ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(msg.Header))
-		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, msg.Header.Get(agentapi.NexTriggerSubject)) //nolint:all
+		ctx := context.WithValue(context.Background(), agentapi.NexTriggerSubject, msg.Header.Get(agentapi.NexTriggerSubject)) //nolint:all
+		ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(msg.Header))
 
 		startTime := time.Now()
 		val, err := v.Execute(ctx, msg.Data)

--- a/agent/providers/lib/v8_nop.go
+++ b/agent/providers/lib/v8_nop.go
@@ -3,9 +3,9 @@
 package lib
 
 import (
+	"context"
 	"errors"
 
-	"github.com/nats-io/nats.go"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
 
@@ -13,7 +13,7 @@ type V8 struct{}
 
 func (V8) Deploy() error { return nil }
 
-func (V8) Execute(headers nats.Header, payload []byte) ([]byte, error) { return []byte{}, nil }
+func (V8) Execute(ctx context.Context, payload []byte) ([]byte, error) { return []byte{}, nil }
 
 func (V8) Undeploy() error { return nil }
 

--- a/agent/providers/lib/v8_nop.go
+++ b/agent/providers/lib/v8_nop.go
@@ -5,6 +5,7 @@ package lib
 import (
 	"errors"
 
+	"github.com/nats-io/nats.go"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 )
 
@@ -12,7 +13,7 @@ type V8 struct{}
 
 func (V8) Deploy() error { return nil }
 
-func (V8) Execute(subject string, payload []byte) ([]byte, error) { return []byte{}, nil }
+func (V8) Execute(headers nats.Header, payload []byte) ([]byte, error) { return []byte{}, nil }
 
 func (V8) Undeploy() error { return nil }
 

--- a/agent/providers/lib/wasm.go
+++ b/agent/providers/lib/wasm.go
@@ -36,7 +36,7 @@ func (e *Wasm) Deploy() error {
 	subject := fmt.Sprintf("agentint.%s.trigger", e.vmID)
 	_, err := e.nc.Subscribe(subject, func(msg *nats.Msg) {
 		ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(msg.Header))
-		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, subject)
+		ctx = context.WithValue(ctx, agentapi.NexTriggerSubject, subject) //nolint:all
 
 		val, err := e.Execute(ctx, msg.Data)
 		if err != nil {

--- a/agent/providers/lib/wasm.go
+++ b/agent/providers/lib/wasm.go
@@ -33,7 +33,7 @@ type Wasm struct {
 func (e *Wasm) Deploy() error {
 	subject := fmt.Sprintf("agentint.%s.trigger", e.vmID)
 	_, err := e.nc.Subscribe(subject, func(msg *nats.Msg) {
-		val, err := e.Execute(msg.Header.Get("x-nex-trigger-subject"), msg.Data)
+		val, err := e.Execute(msg.Header, msg.Data)
 		if err != nil {
 			// TODO-- propagate this error to agent logs
 			return
@@ -51,7 +51,8 @@ func (e *Wasm) Deploy() error {
 	return nil
 }
 
-func (e *Wasm) Execute(subject string, payload []byte) ([]byte, error) {
+func (e *Wasm) Execute(headers nats.Header, payload []byte) ([]byte, error) {
+	subject := headers.Get(agentapi.NexTriggerSubject)
 	ctx := context.Background()
 
 	out := newStdOutBuf()

--- a/host-services/builtins/builtins_client.go
+++ b/host-services/builtins/builtins_client.go
@@ -1,6 +1,7 @@
 package builtins
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -26,16 +27,12 @@ func NewBuiltinServicesClient(hsClient *hostservices.HostServicesClient) *Builti
 	}
 }
 
-func (c *BuiltinServicesClient) KVGet(key string, traceID *string) ([]byte, error) {
+func (c *BuiltinServicesClient) KVGet(ctx context.Context, key string) ([]byte, error) {
 	metadata := map[string]string{
 		agentapi.KeyValueKeyHeader: key,
 	}
 
-	if traceID != nil {
-		metadata[agentapi.OtelTraceparent] = *traceID
-	}
-
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodGet, []byte{}, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodGet, []byte{}, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -47,16 +44,12 @@ func (c *BuiltinServicesClient) KVGet(key string, traceID *string) ([]byte, erro
 	return resp.Data, nil
 }
 
-func (c *BuiltinServicesClient) KVSet(key string, value []byte, traceID *string) (*agentapi.HostServicesKeyValueResponse, error) {
+func (c *BuiltinServicesClient) KVSet(ctx context.Context, key string, value []byte) (*agentapi.HostServicesKeyValueResponse, error) {
 	metadata := map[string]string{
 		agentapi.KeyValueKeyHeader: key,
 	}
 
-	if traceID != nil {
-		metadata[agentapi.OtelTraceparent] = *traceID
-	}
-
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodSet, value, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodSet, value, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -73,16 +66,12 @@ func (c *BuiltinServicesClient) KVSet(key string, value []byte, traceID *string)
 	return &kvResponse, nil
 }
 
-func (c *BuiltinServicesClient) KVDelete(key string, traceID *string) (*agentapi.HostServicesKeyValueResponse, error) {
+func (c *BuiltinServicesClient) KVDelete(ctx context.Context, key string) (*agentapi.HostServicesKeyValueResponse, error) {
 	metadata := map[string]string{
 		agentapi.KeyValueKeyHeader: key,
 	}
 
-	if traceID != nil {
-		metadata[agentapi.OtelTraceparent] = *traceID
-	}
-
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodDelete, []byte{}, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodDelete, []byte{}, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -99,14 +88,10 @@ func (c *BuiltinServicesClient) KVDelete(key string, traceID *string) (*agentapi
 	return &kvResponse, nil
 }
 
-func (c *BuiltinServicesClient) KVKeys(traceID *string) ([]string, error) {
+func (c *BuiltinServicesClient) KVKeys(ctx context.Context) ([]string, error) {
 	metadata := map[string]string{}
 
-	if traceID != nil {
-		metadata[agentapi.OtelTraceparent] = *traceID
-	}
-
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodKeys, []byte{}, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodKeys, []byte{}, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -122,11 +107,12 @@ func (c *BuiltinServicesClient) KVKeys(traceID *string) ([]string, error) {
 	return results, err
 }
 
-func (c *BuiltinServicesClient) MessagingPublish(subject string, payload []byte) error {
+func (c *BuiltinServicesClient) MessagingPublish(ctx context.Context, subject string, payload []byte) error {
 	metadata := map[string]string{
 		agentapi.MessagingSubjectHeader: subject,
 	}
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameMessaging, messagingServiceMethodPublish, payload, metadata)
+
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameMessaging, messagingServiceMethodPublish, payload, metadata)
 	if err != nil {
 		return err
 	}
@@ -151,11 +137,11 @@ func (c *BuiltinServicesClient) MessagingPublish(subject string, payload []byte)
 	return nil
 }
 
-func (c *BuiltinServicesClient) MessagingRequest(subject string, payload []byte) ([]byte, error) {
+func (c *BuiltinServicesClient) MessagingRequest(ctx context.Context, subject string, payload []byte) ([]byte, error) {
 	metadata := map[string]string{
 		agentapi.MessagingSubjectHeader: subject,
 	}
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameMessaging, messagingServiceMethodRequest, payload, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameMessaging, messagingServiceMethodRequest, payload, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -166,11 +152,12 @@ func (c *BuiltinServicesClient) MessagingRequest(subject string, payload []byte)
 	return resp.Data, nil
 }
 
-func (c *BuiltinServicesClient) ObjectGet(objectName string) ([]byte, error) {
+func (c *BuiltinServicesClient) ObjectGet(ctx context.Context, objectName string) ([]byte, error) {
 	metadata := map[string]string{
 		agentapi.ObjectStoreObjectNameHeader: objectName,
 	}
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameObjectStore, objectStoreServiceMethodGet, []byte{}, metadata)
+
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodGet, []byte{}, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -181,9 +168,8 @@ func (c *BuiltinServicesClient) ObjectGet(objectName string) ([]byte, error) {
 	return resp.Data, nil
 }
 
-func (c *BuiltinServicesClient) ObjectList() ([]*nats.ObjectInfo, error) {
-
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameObjectStore, objectStoreServiceMethodList, []byte{}, make(map[string]string))
+func (c *BuiltinServicesClient) ObjectList(ctx context.Context) ([]*nats.ObjectInfo, error) {
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodList, []byte{}, make(map[string]string))
 	if err != nil {
 		return nil, err
 	}
@@ -200,11 +186,11 @@ func (c *BuiltinServicesClient) ObjectList() ([]*nats.ObjectInfo, error) {
 	return theList, nil
 }
 
-func (c *BuiltinServicesClient) ObjectPut(objectName string, payload []byte) (*nats.ObjectInfo, error) {
+func (c *BuiltinServicesClient) ObjectPut(ctx context.Context, objectName string, payload []byte) (*nats.ObjectInfo, error) {
 	metadata := map[string]string{
 		agentapi.ObjectStoreObjectNameHeader: objectName,
 	}
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameObjectStore, objectStoreServiceMethodPut, payload, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodPut, payload, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -220,11 +206,11 @@ func (c *BuiltinServicesClient) ObjectPut(objectName string, payload []byte) (*n
 	return &result, nil
 }
 
-func (c *BuiltinServicesClient) ObjectDelete(objectName string) error {
+func (c *BuiltinServicesClient) ObjectDelete(ctx context.Context, objectName string) error {
 	metadata := map[string]string{
 		agentapi.ObjectStoreObjectNameHeader: objectName,
 	}
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameObjectStore, objectStoreServiceMethodDelete, []byte{}, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodDelete, []byte{}, metadata)
 	if err != nil {
 		return err
 	}
@@ -244,11 +230,11 @@ func (c *BuiltinServicesClient) ObjectDelete(objectName string) error {
 	return nil
 }
 
-func (c *BuiltinServicesClient) SimpleHttpRequest(method string, url string, payload []byte) (*agentapi.HostServicesHTTPResponse, error) {
+func (c *BuiltinServicesClient) SimpleHttpRequest(ctx context.Context, method string, url string, payload []byte) (*agentapi.HostServicesHTTPResponse, error) {
 	metadata := map[string]string{
 		agentapi.HttpURLHeader: url,
 	}
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameHttpClient, method, payload, metadata)
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameHttpClient, method, payload, metadata)
 	if err != nil {
 		return nil, err
 	}

--- a/host-services/builtins/builtins_client.go
+++ b/host-services/builtins/builtins_client.go
@@ -26,9 +26,13 @@ func NewBuiltinServicesClient(hsClient *hostservices.HostServicesClient) *Builti
 	}
 }
 
-func (c *BuiltinServicesClient) KVGet(key string) ([]byte, error) {
+func (c *BuiltinServicesClient) KVGet(key string, traceID *string) ([]byte, error) {
 	metadata := map[string]string{
 		agentapi.KeyValueKeyHeader: key,
+	}
+
+	if traceID != nil {
+		metadata[agentapi.OtelTraceparent] = *traceID
 	}
 
 	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodGet, []byte{}, metadata)
@@ -43,9 +47,13 @@ func (c *BuiltinServicesClient) KVGet(key string) ([]byte, error) {
 	return resp.Data, nil
 }
 
-func (c *BuiltinServicesClient) KVSet(key string, value []byte) (*agentapi.HostServicesKeyValueResponse, error) {
+func (c *BuiltinServicesClient) KVSet(key string, value []byte, traceID *string) (*agentapi.HostServicesKeyValueResponse, error) {
 	metadata := map[string]string{
 		agentapi.KeyValueKeyHeader: key,
+	}
+
+	if traceID != nil {
+		metadata[agentapi.OtelTraceparent] = *traceID
 	}
 
 	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodSet, value, metadata)
@@ -65,9 +73,13 @@ func (c *BuiltinServicesClient) KVSet(key string, value []byte) (*agentapi.HostS
 	return &kvResponse, nil
 }
 
-func (c *BuiltinServicesClient) KVDelete(key string) (*agentapi.HostServicesKeyValueResponse, error) {
+func (c *BuiltinServicesClient) KVDelete(key string, traceID *string) (*agentapi.HostServicesKeyValueResponse, error) {
 	metadata := map[string]string{
 		agentapi.KeyValueKeyHeader: key,
+	}
+
+	if traceID != nil {
+		metadata[agentapi.OtelTraceparent] = *traceID
 	}
 
 	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodDelete, []byte{}, metadata)
@@ -87,8 +99,14 @@ func (c *BuiltinServicesClient) KVDelete(key string) (*agentapi.HostServicesKeyV
 	return &kvResponse, nil
 }
 
-func (c *BuiltinServicesClient) KVKeys() ([]string, error) {
-	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodKeys, []byte{}, make(map[string]string))
+func (c *BuiltinServicesClient) KVKeys(traceID *string) ([]string, error) {
+	metadata := map[string]string{}
+
+	if traceID != nil {
+		metadata[agentapi.OtelTraceparent] = *traceID
+	}
+
+	resp, err := c.hsClient.PerformRpc(builtinServiceNameKeyValue, kvServiceMethodKeys, []byte{}, metadata)
 	if err != nil {
 		return nil, err
 	}

--- a/host-services/builtins/builtins_test.go
+++ b/host-services/builtins/builtins_test.go
@@ -1,6 +1,7 @@
 package builtins
 
 import (
+	"context"
 	"log/slog"
 	"slices"
 	"sync"
@@ -39,7 +40,7 @@ func TestKvBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4446)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(nc, slog.Default())
+	server := hostservices.NewHostServicesServer(context.Background(), nc, slog.Default())
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 
@@ -80,7 +81,7 @@ func TestMessagingBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4447)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(nc, slog.Default())
+	server := hostservices.NewHostServicesServer(context.Background(), nc, slog.Default())
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 
@@ -106,7 +107,7 @@ func TestObjectBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4448)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(nc, slog.Default())
+	server := hostservices.NewHostServicesServer(context.Background(), nc, slog.Default())
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 

--- a/host-services/builtins/builtins_test.go
+++ b/host-services/builtins/builtins_test.go
@@ -1,7 +1,6 @@
 package builtins
 
 import (
-	"context"
 	"log/slog"
 	"slices"
 	"sync"
@@ -20,7 +19,6 @@ const (
 )
 
 func setupSuite(_ testing.TB, port int) (*nats.Conn, func(tb testing.TB)) {
-
 	svr, _ := server.NewServer(&server.Options{
 		Port:      port,
 		Host:      "0.0.0.0",
@@ -40,7 +38,7 @@ func TestKvBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4446)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(context.Background(), nc, slog.Default())
+	server := hostservices.NewHostServicesServer(nc, slog.Default(), nil)
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 
@@ -81,7 +79,7 @@ func TestMessagingBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4447)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(context.Background(), nc, slog.Default())
+	server := hostservices.NewHostServicesServer(nc, slog.Default(), nil)
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 
@@ -107,7 +105,7 @@ func TestObjectBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4448)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(context.Background(), nc, slog.Default())
+	server := hostservices.NewHostServicesServer(nc, slog.Default(), nil)
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 

--- a/host-services/builtins/builtins_test.go
+++ b/host-services/builtins/builtins_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	hostservices "github.com/synadia-io/nex/host-services"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 const (
@@ -39,7 +40,7 @@ func TestKvBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4446)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(nc, slog.Default(), nil)
+	server := hostservices.NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 
@@ -80,7 +81,7 @@ func TestMessagingBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4447)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(nc, slog.Default(), nil)
+	server := hostservices.NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 
@@ -106,7 +107,7 @@ func TestObjectBuiltin(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4448)
 	defer teardownSuite(t)
 
-	server := hostservices.NewHostServicesServer(nc, slog.Default(), nil)
+	server := hostservices.NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
 

--- a/host-services/builtins/builtins_test.go
+++ b/host-services/builtins/builtins_test.go
@@ -67,7 +67,7 @@ func TestKvBuiltin(t *testing.T) {
 		t.Fatalf("Didn't get expected byte array back, got %+v", v)
 	}
 
-	keys, err := bClient.KVKeys(nil)
+	keys, err := bClient.KVKeys(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to get bucket keys: %s", err.Error())
 	}

--- a/host-services/builtins/builtins_test.go
+++ b/host-services/builtins/builtins_test.go
@@ -55,12 +55,12 @@ func TestKvBuiltin(t *testing.T) {
 		t.Fatalf("Failed to start server: %s", err)
 	}
 
-	_, err = bClient.KVSet("testone", []byte{9, 8, 7, 6, 5})
+	_, err = bClient.KVSet("testone", []byte{9, 8, 7, 6, 5}, nil)
 	if err != nil {
 		t.Fatalf("Got an error setting kv: %s", err.Error())
 	}
 
-	v, err := bClient.KVGet("testone")
+	v, err := bClient.KVGet("testone", nil)
 	if err != nil {
 		t.Fatalf("Got an error getting key: %s", err.Error())
 	}
@@ -68,7 +68,7 @@ func TestKvBuiltin(t *testing.T) {
 		t.Fatalf("Didn't get expected byte array back, got %+v", v)
 	}
 
-	keys, err := bClient.KVKeys()
+	keys, err := bClient.KVKeys(nil)
 	if err != nil {
 		t.Fatalf("Failed to get bucket keys: %s", err.Error())
 	}

--- a/host-services/builtins/builtins_test.go
+++ b/host-services/builtins/builtins_test.go
@@ -1,6 +1,7 @@
 package builtins
 
 import (
+	"context"
 	"log/slog"
 	"slices"
 	"sync"
@@ -53,12 +54,12 @@ func TestKvBuiltin(t *testing.T) {
 		t.Fatalf("Failed to start server: %s", err)
 	}
 
-	_, err = bClient.KVSet("testone", []byte{9, 8, 7, 6, 5}, nil)
+	_, err = bClient.KVSet(context.Background(), "testone", []byte{9, 8, 7, 6, 5})
 	if err != nil {
 		t.Fatalf("Got an error setting kv: %s", err.Error())
 	}
 
-	v, err := bClient.KVGet("testone", nil)
+	v, err := bClient.KVGet(context.Background(), "testone")
 	if err != nil {
 		t.Fatalf("Got an error getting key: %s", err.Error())
 	}
@@ -93,7 +94,7 @@ func TestMessagingBuiltin(t *testing.T) {
 		wg.Done()
 	})
 
-	err := bClient.MessagingPublish("foo.bar", []byte("baz"))
+	err := bClient.MessagingPublish(context.Background(), "foo.bar", []byte("baz"))
 	if err != nil {
 		t.Fatalf("Failed to publish message: %s", err)
 	}
@@ -113,7 +114,7 @@ func TestObjectBuiltin(t *testing.T) {
 	_ = server.AddService("objectstore", service, []byte{})
 	_ = server.Start()
 
-	res, err := bClient.ObjectPut("objecttest", []byte{100, 101, 102})
+	res, err := bClient.ObjectPut(context.Background(), "objecttest", []byte{100, 101, 102})
 	if err != nil {
 		t.Fatalf("Expected no error, but got %s", err.Error())
 	}
@@ -124,7 +125,7 @@ func TestObjectBuiltin(t *testing.T) {
 		t.Fatalf("Expected to store 3 bytes, got %d", res.Size)
 	}
 
-	res2, err := bClient.ObjectGet("objecttest")
+	res2, err := bClient.ObjectGet(context.Background(), "objecttest")
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %s", err.Error())
 	}
@@ -132,7 +133,7 @@ func TestObjectBuiltin(t *testing.T) {
 		t.Fatalf("Retrieved the wrong bytes, got %v", res2)
 	}
 
-	infos, err := bClient.ObjectList()
+	infos, err := bClient.ObjectList(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to list objects in bucket")
 	}
@@ -140,12 +141,12 @@ func TestObjectBuiltin(t *testing.T) {
 		t.Fatalf("Got unexpected list of items in bucket: %+v", infos)
 	}
 
-	err = bClient.ObjectDelete("objecttest")
+	err = bClient.ObjectDelete(context.Background(), "objecttest")
 	if err != nil {
 		t.Fatalf("Failed to delete object: %s", err.Error())
 	}
 
-	res3, err := bClient.ObjectGet("objecttest")
+	res3, err := bClient.ObjectGet(context.Background(), "objecttest")
 	if err == nil {
 		t.Fatalf("Expected to get an error for non-existing object but didn't: %+v", res3)
 	}

--- a/host-services/builtins/http.go
+++ b/host-services/builtins/http.go
@@ -44,8 +44,8 @@ func (h *HTTPService) HandleRequest(namespace string,
 	method string,
 	workloadName string,
 	metadata map[string]string,
-	request []byte) (hostservices.ServiceResult, error) {
-
+	request []byte,
+) (hostservices.ServiceResult, error) {
 	switch method {
 	case httpServiceMethodGet:
 		return h.handleGet(workloadId, workloadName, request, metadata)

--- a/host-services/client.go
+++ b/host-services/client.go
@@ -38,14 +38,14 @@ func (c *HostServicesClient) PerformRPC(ctx context.Context, service string, met
 		method,
 	)
 
-	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(metadata))
-
 	msg := nats.NewMsg(subject)
 	msg.Data = payload
 
 	for k, v := range metadata {
 		msg.Header.Set(k, v)
 	}
+
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(msg.Header))
 
 	result, err := c.nc.RequestMsg(msg, c.timeout)
 	if err != nil {

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -94,11 +94,13 @@ func (h *HostServicesServer) handleRPC(msg *nats.Msg) {
 	_, span := h.tracer.Start(ctx, msg.Subject)
 	defer span.End()
 
-	span.AddEvent("host services call", trace.WithAttributes(
+	span.SetAttributes(
 		attribute.KeyValue{Key: "workload_id", Value: attribute.StringValue(vmID)},
 		attribute.KeyValue{Key: "service", Value: attribute.StringValue(serviceName)},
 		attribute.KeyValue{Key: "method", Value: attribute.StringValue(method)},
-	))
+	)
+
+	span.AddEvent("host services call")
 
 	result, err := service.HandleRequest(namespace, vmID, method, workloadName, metadata, msg.Data)
 	if err != nil {
@@ -109,11 +111,7 @@ func (h *HostServicesServer) handleRPC(msg *nats.Msg) {
 		return
 	}
 
-	span.AddEvent("host services call succeeded", trace.WithAttributes(
-		attribute.KeyValue{Key: "workload_id", Value: attribute.StringValue(vmID)},
-		attribute.KeyValue{Key: "service", Value: attribute.StringValue(serviceName)},
-		attribute.KeyValue{Key: "method", Value: attribute.StringValue(method)},
-	))
+	span.AddEvent("host services call succeeded")
 
 	serverMsg := serverSuccessMessage(msg.Reply, result.Code, result.Data, messageOk)
 	_ = msg.RespondMsg(serverMsg)

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/nats-io/nats.go"
+	agentapi "github.com/synadia-io/nex/internal/agent-api"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -85,6 +86,8 @@ func (h *HostServicesServer) handleRPC(msg *nats.Msg) {
 	for k, v := range msg.Header {
 		metadata[k] = v[0]
 	}
+
+	h.log.Debug("traceparent context", slog.String("traceparent", msg.Header.Get(agentapi.OtelTraceparent)))
 
 	cctx := otel.GetTextMapPropagator().Extract(h.ctx, propagation.HeaderCarrier(msg.Header))
 	span := trace.SpanFromContext(cctx)

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -98,7 +98,7 @@ func (h *HostServicesServer) handleRPC(msg *nats.Msg) {
 		))
 	defer span.End()
 
-	span.AddEvent("RPC request")
+	span.AddEvent("RPC Request Began")
 
 	result, err := service.HandleRequest(namespace, vmID, method, workloadName, metadata, msg.Data)
 	if err != nil {
@@ -116,7 +116,7 @@ func (h *HostServicesServer) handleRPC(msg *nats.Msg) {
 		return
 	}
 
-	span.AddEvent("RPC request succeeded")
+	span.AddEvent("RPC Request Completed")
 
 	serverMsg := serverSuccessMessage(msg.Reply, result.Code, result.Data, messageOk)
 	_ = msg.RespondMsg(serverMsg)

--- a/host-services/service_test.go
+++ b/host-services/service_test.go
@@ -1,7 +1,6 @@
 package hostservices
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -40,7 +39,7 @@ func TestBogusService(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4444)
 	defer teardownSuite(t)
 
-	server := NewHostServicesServer(context.Background(), nc, slog.Default())
+	server := NewHostServicesServer(nc, slog.Default(), nil)
 	client := NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 
 	boguss := bogusService{
@@ -79,7 +78,7 @@ func TestServiceError(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4445)
 	defer teardownSuite(t)
 
-	server := NewHostServicesServer(context.Background(), nc, slog.Default())
+	server := NewHostServicesServer(nc, slog.Default(), nil)
 	client := NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 
 	boguss := bogusService{

--- a/host-services/service_test.go
+++ b/host-services/service_test.go
@@ -1,6 +1,7 @@
 package hostservices
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -56,6 +57,7 @@ func TestBogusService(t *testing.T) {
 	}
 
 	result, err := client.PerformRPC(
+		context.Background(),
 		"boguss",
 		"test",
 		[]byte{9, 9, 9},
@@ -95,6 +97,7 @@ func TestServiceError(t *testing.T) {
 	}
 
 	result, _ := client.PerformRPC(
+		context.Background(),
 		"boguss",
 		"test",
 		[]byte{9, 9, 9},

--- a/host-services/service_test.go
+++ b/host-services/service_test.go
@@ -1,6 +1,7 @@
 package hostservices
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -39,7 +40,7 @@ func TestBogusService(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4444)
 	defer teardownSuite(t)
 
-	server := NewHostServicesServer(nc, slog.Default())
+	server := NewHostServicesServer(context.Background(), nc, slog.Default())
 	client := NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 
 	boguss := bogusService{
@@ -78,7 +79,7 @@ func TestServiceError(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4445)
 	defer teardownSuite(t)
 
-	server := NewHostServicesServer(nc, slog.Default())
+	server := NewHostServicesServer(context.Background(), nc, slog.Default())
 	client := NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 
 	boguss := bogusService{

--- a/host-services/service_test.go
+++ b/host-services/service_test.go
@@ -55,7 +55,7 @@ func TestBogusService(t *testing.T) {
 		panic(err)
 	}
 
-	result, err := client.PerformRpc(
+	result, err := client.PerformRPC(
 		"boguss",
 		"test",
 		[]byte{9, 9, 9},
@@ -94,7 +94,7 @@ func TestServiceError(t *testing.T) {
 		panic(err)
 	}
 
-	result, _ := client.PerformRpc(
+	result, _ := client.PerformRPC(
 		"boguss",
 		"test",
 		[]byte{9, 9, 9},

--- a/host-services/service_test.go
+++ b/host-services/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 const (
@@ -40,7 +41,7 @@ func TestBogusService(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4444)
 	defer teardownSuite(t)
 
-	server := NewHostServicesServer(nc, slog.Default(), nil)
+	server := NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 
 	boguss := bogusService{
@@ -80,7 +81,7 @@ func TestServiceError(t *testing.T) {
 	nc, teardownSuite := setupSuite(t, 4445)
 	defer teardownSuite(t)
 
-	server := NewHostServicesServer(nc, slog.Default(), nil)
+	server := NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 
 	boguss := bogusService{

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -208,7 +208,6 @@ func (a *AgentClient) UptimeMillis() time.Duration {
 
 func (a *AgentClient) RunTrigger(ctx context.Context, tracer trace.Tracer, subject string, data []byte) (*nats.Msg, error) {
 	intmsg := nats.NewMsg(fmt.Sprintf("agentint.%s.trigger", a.agentID))
-	// TODO: inject tracer context into message header
 	intmsg.Header.Add(NexTriggerSubject, subject)
 	intmsg.Data = data
 

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -25,6 +25,7 @@ type LogCallback func(string, LogEntry)
 const (
 	NexTriggerSubject = "x-nex-trigger-subject"
 	NexRuntimeNs      = "x-nex-runtime-ns"
+	OtelTraceparent   = "Traceparent"
 
 	HttpURLHeader = "x-http-url"
 

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -25,7 +25,6 @@ type LogCallback func(string, LogEntry)
 const (
 	NexTriggerSubject = "x-nex-trigger-subject"
 	NexRuntimeNs      = "x-nex-runtime-ns"
-	OtelTraceparent   = "Traceparent"
 
 	HttpURLHeader = "x-http-url"
 

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -220,8 +220,6 @@ func (a *AgentClient) RunTrigger(ctx context.Context, tracer trace.Tracer, subje
 
 	otel.GetTextMapPropagator().Inject(cctx, propagation.HeaderCarrier(intmsg.Header))
 
-	// TODO: make the agent's exec handler extract and forward the otel context
-	// so it continues in the host services like kv, obj, msg, etc
 	resp, err := a.nc.RequestMsg(intmsg, time.Millisecond*10000) // FIXME-- make timeout configurable
 	childSpan.End()
 

--- a/internal/node/services.go
+++ b/internal/node/services.go
@@ -33,7 +33,8 @@ func NewHostServices(
 	ncint *nats.Conn,
 	ncHostServices *nats.Conn,
 	config *models.HostServicesConfig,
-	log *slog.Logger) *HostServices {
+	log *slog.Logger,
+) *HostServices {
 	return &HostServices{
 		log:            log,
 		mgr:            mgr,
@@ -45,7 +46,7 @@ func NewHostServices(
 		//
 		// Sincerely,
 		//     Someone who lost a day of troubleshooting
-		hsServer: hs.NewHostServicesServer(ncint, log),
+		hsServer: hs.NewHostServicesServer(mgr.ctx, ncint, log),
 	}
 }
 

--- a/internal/node/services.go
+++ b/internal/node/services.go
@@ -46,7 +46,7 @@ func NewHostServices(
 		//
 		// Sincerely,
 		//     Someone who lost a day of troubleshooting
-		hsServer: hs.NewHostServicesServer(mgr.ctx, ncint, log),
+		hsServer: hs.NewHostServicesServer(ncint, log, mgr.t.Tracer),
 	}
 }
 

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -478,9 +478,6 @@ func (w *WorkloadManager) generateTriggerHandler(workloadID string, tsub string,
 
 		resp, err := agentClient.RunTrigger(ctx, w.t.Tracer, msg.Subject, msg.Data)
 
-		//for reference - this is what agent exec would do
-		//ctx = otel.GetTextMapPropagator().Extract(cctx, propagation.HeaderCarrier(msg.Header))
-
 		parentSpan.AddEvent("Completed internal request")
 		if err != nil {
 			parentSpan.SetStatus(codes.Error, "Internal trigger request failed")

--- a/test/wasm_test.go
+++ b/test/wasm_test.go
@@ -45,7 +45,7 @@ func TestWasmExecution(t *testing.T) {
 	input := []byte("Hello world")
 	subject := "test.trigger"
 
-	ctx := context.WithValue(context.Background(), agentapi.MessagingSubjectHeader, subject) //nolint:all
+	ctx := context.WithValue(context.Background(), agentapi.NexTriggerSubject, subject) //nolint:all
 	output, err := wasm.Execute(ctx, input)
 	if err != nil {
 		t.Fatalf("Failed to run trigger: %s", err)

--- a/test/wasm_test.go
+++ b/test/wasm_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/synadia-io/nex/agent/providers/lib"
@@ -44,7 +45,8 @@ func TestWasmExecution(t *testing.T) {
 	input := []byte("Hello world")
 	subject := "test.trigger"
 
-	output, err := wasm.Execute(subject, input)
+	ctx := context.WithValue(context.Background(), agentapi.MessagingSubjectHeader, subject) //nolint:all
+	output, err := wasm.Execute(ctx, input)
 	if err != nil {
 		t.Fatalf("Failed to run trigger: %s", err)
 	}


### PR DESCRIPTION
This PR adds otel child span support for tracing host services execution.

![image](https://github.com/synadia-io/nex/assets/161261/81fc8b54-1a1c-4c3e-98e2-48568aa597ca)

Closes #132.