### PR TITLE
adds ping to agent process for client monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist/
 nex/nex
 rootfs.ext4
 
+test/panicker/panicker
 .idea
 
 _spec

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -21,6 +21,7 @@ import (
 type HandshakeCallback func(string)
 type EventCallback func(string, cloudevents.Event)
 type LogCallback func(string, LogEntry)
+type ContactLostCallback func(string)
 
 const (
 	NexTriggerSubject = "x-nex-trigger-subject"
@@ -47,6 +48,7 @@ type AgentClient struct {
 	handshakeSucceeded HandshakeCallback
 	eventReceived      EventCallback
 	logReceived        LogCallback
+	contactLost        ContactLostCallback
 
 	execTotalNanos    int64
 	workloadStartedAt time.Time
@@ -62,6 +64,7 @@ func NewAgentClient(
 	onSuccess HandshakeCallback,
 	onEvent EventCallback,
 	onLog LogCallback,
+	onContactLost ContactLostCallback,
 ) *AgentClient {
 	return &AgentClient{
 		eventReceived:      onEvent,
@@ -69,6 +72,7 @@ func NewAgentClient(
 		handshakeTimeout:   handshakeTimeout,
 		handshakeTimedOut:  onTimedOut,
 		handshakeSucceeded: onSuccess,
+		contactLost:        onContactLost,
 		log:                log,
 		logReceived:        onLog,
 		nc:                 nc,
@@ -192,6 +196,18 @@ func (a *AgentClient) Undeploy() error {
 	return nil
 }
 
+func (a *AgentClient) Ping() error {
+	subject := fmt.Sprintf("agentint.%s.ping", a.agentID)
+
+	_, err := a.nc.Request(subject, []byte{}, 750*time.Millisecond)
+	if err != nil {
+		a.log.Warn("Agent failed to respond to ping", slog.Any("error", err))
+		return err
+	}
+
+	return nil
+}
+
 func (a *AgentClient) RecordExecTime(elapsedNanos int64) {
 	atomic.AddInt64(&a.execTotalNanos, elapsedNanos)
 }
@@ -259,6 +275,21 @@ func (a *AgentClient) handleHandshake(msg *nats.Msg) {
 
 	a.handshakeReceived.Store(true)
 	a.handshakeSucceeded(*req.ID)
+	go a.monitorAgent()
+}
+
+func (a *AgentClient) monitorAgent() {
+	ticker := time.NewTicker(15 * time.Second)
+	for {
+		<-ticker.C
+		err := a.Ping()
+		if err != nil {
+			if a.contactLost != nil {
+				a.contactLost(a.agentID)
+			}
+			break
+		}
+	}
 }
 
 func (a *AgentClient) handleAgentEvent(msg *nats.Msg) {

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -289,6 +289,9 @@ func (a *AgentClient) monitorAgent() {
 			}
 			break
 		}
+		if a.stopping > 0 {
+			break
+		}
 	}
 }
 

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -424,6 +424,7 @@ func (w *WorkloadManager) OnProcessStarted(id string) {
 		w.agentHandshakeSucceeded,
 		w.agentEvent,
 		w.agentLog,
+		w.agentContactLost,
 	)
 
 	err := agentClient.Start(id)
@@ -452,6 +453,13 @@ func (w *WorkloadManager) agentHandshakeTimedOut(id string) {
 func (w *WorkloadManager) agentHandshakeSucceeded(workloadID string) {
 	now := time.Now().UTC()
 	w.handshakes[workloadID] = now.Format(time.RFC3339)
+}
+
+func (w *WorkloadManager) agentContactLost(workloadID string) {
+	w.log.Warn("Lost contact with agent", slog.String("workload_id", workloadID))
+	delete(w.activeAgents, workloadID)
+	delete(w.pendingAgents, workloadID)
+	_ = w.procMan.StopProcess(workloadID)
 }
 
 // Generate a NATS subscriber function that is used to trigger function-type workloads

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -457,9 +457,7 @@ func (w *WorkloadManager) agentHandshakeSucceeded(workloadID string) {
 
 func (w *WorkloadManager) agentContactLost(workloadID string) {
 	w.log.Warn("Lost contact with agent", slog.String("workload_id", workloadID))
-	delete(w.activeAgents, workloadID)
-	delete(w.pendingAgents, workloadID)
-	_ = w.procMan.StopProcess(workloadID)
+	_ = w.StopWorkload(workloadID, false)
 }
 
 // Generate a NATS subscriber function that is used to trigger function-type workloads

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -357,6 +357,7 @@ func (w *WorkloadManager) Stop() error {
 func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
 	defer func() {
 		delete(w.activeAgents, id)
+		delete(w.pendingAgents, id)
 		delete(w.stopMutex, id)
 
 		_ = w.publishWorkloadStopped(id)
@@ -369,8 +370,10 @@ func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
 	}
 
 	mutex := w.stopMutex[id]
-	mutex.Lock()
-	defer mutex.Unlock()
+	if mutex != nil {
+		mutex.Lock()
+		defer mutex.Unlock()
+	}
 
 	w.log.Debug("Attempting to stop workload", slog.String("workload_id", id), slog.Bool("undeploy", undeploy))
 

--- a/test/panicker/main.go
+++ b/test/panicker/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// Statically compile this and deploy it to test situations when we want to see
+// how the system responds to a workload crash
+func main() {
+	fmt.Println("Everything is fine. Nothing to see here. Please disperse.")
+
+	r := rand.Intn(5) + 5
+	time.Sleep(time.Duration(r) * time.Second)
+
+	err := errors.New("something terrible has happened")
+	fmt.Printf("failure: %s\n", err)
+
+	panic(err)
+}


### PR DESCRIPTION
The node will now ping all agent processes (pending or deployed/active). If the agent fails to respond, the node will remove that agent from its known agents pool and ask the procman to try and shut it down (which should be idempotent and safe).

The agent dying looks something like this:

```
cp3kus752omnmk6of1hg | [INFO] 2024-05-17 08:38:47 - Received signal: terminated workload_id=cp3kus752omnmk6of1hg from_agent=true
[INFO] 2024-05-17 08:38:47 - Agent command exited cleanly pid=227201
[WARN] 2024-05-17 08:38:49 - Agent failed to respond to ping error=nats: timeout
[WARN] 2024-05-17 08:38:49 - Lost contact with agent workload_id=cp3kus752omnmk6of1hg
[ERROR] 2024-05-17 08:38:49 - Failed to interrupt agent process agent_id=cp3kus752omnmk6of1hg pid=227201 err=os: process already finished
```

In most cases we should be able to clean things up but in case an agent fails and none of the other methods capture this, the ping failure is a pretty deterministic way to decide to remove the agent from a pool.