### PR TITLE
Preliminary support for account security in nats internal server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ pnats
 .idea
 
 _spec
+
+/internal/node/internal-nats/pnats

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ pnats
 _spec
 
 /internal/node/internal-nats/pnats
+/nex/pnats

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,7 +14,7 @@ tasks:
     sources:
       - "*.go"
     cmds:
-      - go build -tags netgo -ldflags '-extldflags "-static"'
+      - CGO_ENABLED=0 go build -tags netgo -ldflags '-extldflags "-static"'
 
   clean:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,7 +14,7 @@ tasks:
     sources:
       - "*.go"
     cmds:
-      - CGO_ENABLED=0 go build -tags netgo -ldflags '-extldflags "-static"'
+      - go build -tags netgo -ldflags '-extldflags "-static"'
 
   clean:
     cmds:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -345,6 +345,7 @@ func (a *Agent) handleUndeploy(m *nats.Msg) {
 }
 
 func (a *Agent) handlePing(m *nats.Msg) {
+	a.LogDebug(fmt.Sprintf("received ping on subject: %s", m.Subject))
 	_ = m.Respond([]byte("OK"))
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -82,6 +82,7 @@ func NewAgent(ctx context.Context, cancelF context.CancelFunc) (*Agent, error) {
 	}
 	pk, _ := pair.PublicKey()
 	nc, err := nats.Connect(url, nats.Nkey(pk, func(b []byte) ([]byte, error) {
+		fmt.Fprintf(os.Stdout, "Attempting to sign NATS server nonce for internal workload connection; public key: %s", pk)
 		return pair.Sign(b)
 	}))
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -76,6 +76,10 @@ func NewAgent(ctx context.Context, cancelF context.CancelFunc) (*Agent, error) {
 
 	url := fmt.Sprintf("nats://%s:%d", *metadata.NodeNatsHost, *metadata.NodeNatsPort)
 	pair, err := nkeys.FromSeed([]byte(*metadata.NodeNatsNkeySeed))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid nkey seed: %v\n", metadata.Errors)
+		return nil, fmt.Errorf("invalid nkey seed: %v", metadata.Errors)
+	}
 	pk, _ := pair.PublicKey()
 	nc, err := nats.Connect(url, nats.Nkey(pk, func(b []byte) ([]byte, error) {
 		return pair.Sign(b)

--- a/agent/metadata.go
+++ b/agent/metadata.go
@@ -21,6 +21,7 @@ const nexEnvSandbox = "NEX_SANDBOX"
 const nexEnvWorkloadID = "NEX_WORKLOADID"
 const nexEnvNodeNatsHost = "NEX_NODE_NATS_HOST"
 const nexEnvNodeNatsPort = "NEX_NODE_NATS_PORT"
+const nexEnvNodeNatsSeed = "NEX_NODE_NATS_NKEY_SEED"
 
 const metadataClientTimeoutMillis = 50
 const metadataPollingTimeoutMillis = 5000
@@ -71,6 +72,7 @@ func GetMachineMetadataFromEnv() (*agentapi.MachineMetadata, error) {
 	vmid := os.Getenv(nexEnvWorkloadID)
 	host := os.Getenv(nexEnvNodeNatsHost)
 	port := os.Getenv(nexEnvNodeNatsPort)
+	seed := os.Getenv(nexEnvNodeNatsSeed)
 	msg := "Metadata obtained from no-sandbox environment"
 	p, err := strconv.Atoi(port)
 	if err != nil {
@@ -79,10 +81,11 @@ func GetMachineMetadataFromEnv() (*agentapi.MachineMetadata, error) {
 	}
 
 	return &agentapi.MachineMetadata{
-		VmID:         &vmid,
-		NodeNatsHost: &host,
-		NodeNatsPort: &p,
-		Message:      &msg,
+		VmID:             &vmid,
+		NodeNatsHost:     &host,
+		NodeNatsPort:     &p,
+		NodeNatsNkeySeed: &seed,
+		Message:          &msg,
 	}, nil
 }
 

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -183,6 +183,7 @@ func (v *V8) Execute(ctx context.Context, payload []byte) ([]byte, error) {
 			return
 		}
 
+		_, _ = v.stdout.Write([]byte(fmt.Sprintf("calling js function via trigger subject: %s", subject)))
 		val, err = fn.Call(v8ctx.Global(), argv1, argv2)
 		if err != nil {
 			errs <- err
@@ -543,6 +544,8 @@ func (v *V8) newMessagingObjectTemplate(ctx context.Context) *v8.ObjectTemplate 
 	messaging := v8.NewObjectTemplate(v.iso)
 
 	_ = messaging.Set(hostServicesMessagingPublishFunctionName, v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		_, _ = v.stdout.Write([]byte(fmt.Sprintf("attempting to publish msg via %s", v.nc.Servers()[0])))
+
 		args := info.Args()
 		if len(args) != 2 {
 			val, _ := v8.NewValue(v.iso, "subject and payload are required")
@@ -847,7 +850,7 @@ func InitNexExecutionProviderV8(params *agentapi.ExecutionProviderParams) (*V8, 
 
 	hsclient := hostservices.NewHostServicesClient(
 		params.NATSConn,
-		time.Second*2,
+		time.Second*5, // FIXME-- make configurable
 		*params.Namespace,
 		*params.WorkloadName,
 		params.VmID,

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/nats-io/nats.go v1.34.1
 	github.com/nats-io/natscli v0.1.4
 	github.com/nats-io/nkeys v0.4.7
+	github.com/nats-io/nuid v1.0.1
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/pkg/errors v0.9.1
@@ -109,7 +110,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/host-services/builtins/keyvalue.go
+++ b/host-services/builtins/keyvalue.go
@@ -60,8 +60,8 @@ func (k *KeyValueService) HandleRequest(
 	method string,
 	workloadName string,
 	metadata map[string]string,
-	request []byte) (hostservices.ServiceResult, error) {
-
+	request []byte,
+) (hostservices.ServiceResult, error) {
 	switch method {
 	case kvServiceMethodGet:
 		return k.handleGet(workloadId, workloadName, request, metadata, namespace)
@@ -208,5 +208,6 @@ func (k *KeyValueService) resolveKeyValueStore(namespace, workload string) (nats
 		}
 	}
 
+	k.log.Debug("Resolved key/value store for KV host service", slog.String("name", kvStoreName), slog.String("bucket", kvStore.Bucket()))
 	return kvStore, nil
 }

--- a/host-services/client.go
+++ b/host-services/client.go
@@ -30,7 +30,7 @@ func NewHostServicesClient(nc *nats.Conn, timeout time.Duration, namespace, work
 }
 
 func (c *HostServicesClient) PerformRPC(ctx context.Context, service string, method string, payload []byte, metadata map[string]string) (ServiceResult, error) {
-	subject := fmt.Sprintf("agentint.%s.rpc.%s.%s.%s.%s",
+	subject := fmt.Sprintf("hostint.%s.rpc.%s.%s.%s.%s",
 		c.workloadId,
 		c.namespace,
 		c.workloadName,

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -52,9 +52,11 @@ func (h *HostServicesServer) AddService(name string, svc HostService, config jso
 func (h *HostServicesServer) Start() error {
 	_, err := h.nc.Subscribe("agentint.*.rpc.*.*.*.*", h.handleRPC)
 	if err != nil {
+		h.log.Warn("Failed to create Host services rpc subscription", slog.String("error", err.Error()))
 		return err
 	}
 
+	h.log.Debug("Host services rpc subscription created", slog.String("address", h.nc.ConnectedAddr()))
 	return nil
 }
 

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -49,8 +49,13 @@ func (h *HostServicesServer) AddService(name string, svc HostService, config jso
 	return nil
 }
 
+// Host services server instances subscribe to the following `hostint.>` subjects,
+// which are exported by the `nexnode` account on the configured internal
+// NATS connection for consumption by agents:
+//
+// - hostint.<agent_id>.rpc.<namespace>.<workloadName>.<service>.<method>
 func (h *HostServicesServer) Start() error {
-	_, err := h.nc.Subscribe("agentint.*.rpc.*.*.*.*", h.handleRPC)
+	_, err := h.nc.Subscribe("hostint.*.rpc.*.*.*.*", h.handleRPC)
 	if err != nil {
 		h.log.Warn("Failed to create Host services rpc subscription", slog.String("error", err.Error()))
 		return err

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -15,18 +15,18 @@ import (
 )
 
 type HostServicesServer struct {
-	log        *slog.Logger
-	ncInternal *nats.Conn
-	services   map[string]HostService
-	tracer     trace.Tracer
+	log      *slog.Logger
+	nc       *nats.Conn
+	services map[string]HostService
+	tracer   trace.Tracer
 }
 
 func NewHostServicesServer(nc *nats.Conn, log *slog.Logger, tracer trace.Tracer) *HostServicesServer {
 	return &HostServicesServer{
-		ncInternal: nc,
-		log:        log,
-		services:   make(map[string]HostService),
-		tracer:     tracer,
+		log:      log,
+		nc:       nc,
+		services: make(map[string]HostService),
+		tracer:   tracer,
 	}
 }
 
@@ -50,7 +50,7 @@ func (h *HostServicesServer) AddService(name string, svc HostService, config jso
 }
 
 func (h *HostServicesServer) Start() error {
-	_, err := h.ncInternal.Subscribe("agentint.*.rpc.*.*.*.*", h.handleRPC)
+	_, err := h.nc.Subscribe("agentint.*.rpc.*.*.*.*", h.handleRPC)
 	if err != nil {
 		return err
 	}

--- a/host-services/service.go
+++ b/host-services/service.go
@@ -43,10 +43,13 @@ func ServiceResultPass(code uint, message string, data []byte) ServiceResult {
 
 type HostService interface {
 	Initialize(json.RawMessage) error
-	HandleRequest(namespace string,
+
+	HandleRequest(
+		namespace string,
 		workloadId string,
 		method string,
 		workloadName string,
 		metadata map[string]string,
-		request []byte) (ServiceResult, error)
+		request []byte,
+	) (ServiceResult, error)
 }

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -204,7 +204,7 @@ func (a *AgentClient) Undeploy() error {
 
 func (a *AgentClient) Ping() error {
 	subject := fmt.Sprintf("agentint.%s.ping", a.agentID)
-	a.log.Debug("pinging agent", slog.String("subject", subject))
+	// a.log.Debug("pinging agent", slog.String("subject", subject))
 
 	_, err := a.nc.Request(subject, []byte{}, a.pingTimeout)
 	if err != nil {

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -144,6 +144,7 @@ func (a *AgentClient) DeployWorkload(request *DeployRequest) (*DeployResponse, e
 		a.log.Error("Failed to deserialize deployment response", slog.Any("error", err))
 		return nil, err
 	}
+
 	a.workloadStartedAt = time.Now().UTC()
 	return &deployResponse, nil
 }
@@ -183,6 +184,8 @@ func (a *AgentClient) Stop() error {
 }
 
 func (a *AgentClient) Undeploy() error {
+	_ = a.Stop()
+
 	subject := fmt.Sprintf("agentint.%s.undeploy", a.agentID)
 
 	a.log.Debug("sending undeploy request to agent via internal NATS connection",
@@ -195,6 +198,7 @@ func (a *AgentClient) Undeploy() error {
 		a.log.Warn("request to undeploy workload via internal NATS connection failed", slog.String("agent_id", a.agentID), slog.String("error", err.Error()))
 		return err
 	}
+
 	return nil
 }
 

--- a/internal/agent-api/types.go
+++ b/internal/agent-api/types.go
@@ -183,7 +183,9 @@ type MachineMetadata struct {
 	VmID         *string `json:"vmid"`
 	NodeNatsHost *string `json:"node_nats_host"`
 	NodeNatsPort *int    `json:"node_nats_port"`
-	Message      *string `json:"message"`
+	// To be used when agents use the new internal nats security
+	NodeNatsNkeySeed *string `json:"node_nats_nkey"`
+	Message          *string `json:"message"`
 
 	Errors []error `json:"errors,omitempty"`
 }

--- a/internal/agent-api/types.go
+++ b/internal/agent-api/types.go
@@ -38,7 +38,7 @@ type ExecutionProviderParams struct {
 	TmpFilename *string `json:"-"`
 	VmID        string  `json:"-"`
 
-	// NATS connection which be injected into the execution provider
+	// NATS connections which be injected into the execution provider
 	NATSConn *nats.Conn `json:"-"`
 }
 
@@ -180,10 +180,9 @@ type HostServicesMessagingResponse struct {
 }
 
 type MachineMetadata struct {
-	VmID         *string `json:"vmid"`
-	NodeNatsHost *string `json:"node_nats_host"`
-	NodeNatsPort *int    `json:"node_nats_port"`
-	// To be used when agents use the new internal nats security
+	VmID             *string `json:"vmid"`
+	NodeNatsHost     *string `json:"node_nats_host"`
+	NodeNatsPort     *int    `json:"node_nats_port"`
 	NodeNatsNkeySeed *string `json:"node_nats_nkey"`
 	Message          *string `json:"message"`
 

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -21,6 +21,7 @@ const (
 	DefaultNodeVcpuCount                    = 1
 	DefaultOtelExporterUrl                  = "127.0.0.1:14532"
 	DefaultAgentHandshakeTimeoutMillisecond = 5000
+	DefaultAgentPingTimeoutMillisecond      = 750
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 // as the virtual machines it produces
 type NodeConfiguration struct {
 	AgentHandshakeTimeoutMillisecond int                 `json:"agent_handshake_timeout_ms,omitempty"`
+	AgentPingTimeoutMillisecond      int                 `json:"agent_ping_timeout_ms,omitempty"`
 	BinPath                          []string            `json:"bin_path"`
 	CNI                              CNIDefinition       `json:"cni"`
 	DefaultResourceDir               string              `json:"default_resource_dir"`
@@ -144,6 +146,7 @@ func DefaultNodeConfiguration() NodeConfiguration {
 
 	config := NodeConfiguration{
 		AgentHandshakeTimeoutMillisecond: DefaultAgentHandshakeTimeoutMillisecond,
+		AgentPingTimeoutMillisecond:      DefaultAgentPingTimeoutMillisecond,
 		BinPath:                          DefaultBinPath,
 		// CAUTION: This needs to be the IP of the node server's internal NATS --as visible to the agent.
 		// This is not necessarily the address on which the internal NATS server is actually listening inside the node.

--- a/internal/node/controlapi.go
+++ b/internal/node/controlapi.go
@@ -29,6 +29,7 @@ type ApiListener struct {
 	subz []*nats.Subscription
 }
 
+// FIXME-- stop passing node here
 func NewApiListener(log *slog.Logger, mgr *WorkloadManager, node *Node) *ApiListener {
 	config := node.config
 
@@ -283,7 +284,7 @@ func (api *ApiListener) handleDeploy(m *nats.Msg) {
 
 	workloadID := agentClient.ID()
 
-	numBytes, workloadHash, err := api.mgr.CacheWorkload(api.node.natsint, workloadID, &request)
+	numBytes, workloadHash, err := api.mgr.CacheWorkload(workloadID, &request)
 	if err != nil {
 		api.log.Error("Failed to cache workload bytes", slog.Any("err", err))
 		respondFail(controlapi.RunResponseType, m, fmt.Sprintf("Failed to cache workload bytes: %s", err))

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -33,7 +33,6 @@ accounts: {
 	nexhost: {
 		jetstream: true		
 		users: [
-			{user: nex, password: pass}
 			{nkey: "{{ .NexHostUserPublic }}"}
 		]
 		exports: [

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -1,0 +1,138 @@
+package internalnats
+
+import (
+	"bytes"
+	"log/slog"
+	"text/template"
+)
+
+type internalServerData struct {
+	// workloadID -> userData
+	Users             []userData
+	NexHostUserPublic string
+	NexHostUserSeed   string
+}
+
+type userData struct {
+	WorkloadID string
+	NkeySeed   string
+	NkeyPublic string
+}
+
+/*
+ * In the below template, the nexhost (the account used by the host) will
+ * be able to import the following:
+ * *.agentevt.> - agent events streamed from workloads
+ * agentint.> - where the first token after agentint is the account ID from the workload
+ */
+
+const (
+	configTemplate = `
+jetstream: true
+
+accounts: {
+	nexhost: {
+		jetstream: true		
+		users: [
+			{nkey: "{{ .NexHostUserPublic }}"}
+		]
+		exports: [
+			{
+				service: agentint.>
+			}
+		],
+		imports: [
+			{{range .Users }}
+			{
+				stream: {subject: agentevt.>, account: {{ .WorkloadID }}}, prefix: {{ .WorkloadID }} 
+			},
+			{{ end }}
+		]	
+	},
+	{{ range .Users }}
+	{{ .WorkloadID }}: {
+		jetstream: true
+		users: [
+			{nkey: "{{ .NkeyPublic }}"}
+		]
+		imports: [
+			{service: {account: nexhost, subject: agentint.{{ .WorkloadID }}.>}, to: agentint.>}
+		]
+		exports: [
+			{stream: agentevt.>, accounts: [nexhost]}
+		]
+	},
+	{{ end }}	
+}
+no_sys_acc: true
+`
+)
+
+func GenerateFile(log *slog.Logger, config internalServerData) ([]byte, error) {
+	t := template.Must(template.New("natsconfig").Parse(configTemplate))
+
+	var wr bytes.Buffer
+	err := t.Execute(&wr, config)
+	if err != nil {
+		return nil, err
+	}
+	return wr.Bytes(), nil
+}
+
+/*
+exports: [
+			{
+				service: agentint.>
+			}
+		],
+		imports: [
+			{{range .Users }}
+			{
+				stream: {subject: agentevt.>, account: {{ .AccountPublicKey }}}, prefix: {{ .AccountPublicKey }} }
+			},
+			{{ end }}
+		]
+	},
+	{{ range .Users }}
+	{{ .AccountPublicKey }}: {
+		users: [
+			{nkey: {{ .NkeyPublic }}}
+		]
+		imports: [
+			{service: {account: nexhost, subject: agentint.{{ .AccountPublicKey }}.>}, to: agentint.>}
+		]
+		exports: [
+			{stream: agentevt.>, accounts: [nexhost]}
+		]
+	},
+	{{ end }}
+*/
+
+/*
+
+listen: 0.0.0.0:4229
+accounts: {
+    nexhost: {
+        users: [
+            {nkey: UCNGL4W5QX66CFX6A6DCBVDH5VOHMI7B2UZZU7TXAUQQSI2JPHULCKBR}
+        ],
+        exports: [
+            {service: agentint.>}
+        ]
+        imports: [
+            {stream: {subject: agentevt.>, account: PKIbeHP9gWD}, prefix: PKIbeHP9gWD}
+        ]
+    }
+    PKIbeHP9gWD: {
+        users: [
+            {nkey: UDPGQVFIWZ7Q5UH4I5E6DBCZULQS6VTVBG6CYBD7JV3G3N2GMQOMNAUH}
+        ]
+        imports: [
+            {service: {account: nexhost, subject: agentint.PKIbeHP9gWD.>}, to: agentint.>}
+        ]
+        exports: [
+            {stream: agentevt.>, accounts: [nexhost]}
+        ]
+    }
+}
+*/

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -89,6 +89,6 @@ func GenerateTemplate(log *slog.Logger, config internalServerData) ([]byte, erro
 		return nil, err
 	}
 
-	log.Debug("generated NATS config", slog.String("config", string(wr.Bytes())))
+	log.Debug("generated NATS config", slog.String("config", wr.String()))
 	return wr.Bytes(), nil
 }

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -10,11 +10,10 @@ type internalServerData struct {
 	Credentials       map[string]*credentials
 	NexHostUserPublic string
 	NexHostUserSeed   string
-	Users             []credentials
 }
 
 type credentials struct {
-	WorkloadID string
+	ID         string
 	NkeySeed   string
 	NkeyPublic string
 }

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -22,7 +22,7 @@ type credentials struct {
  * In the below template, the nexhost (the account used by the host) will
  * be able to import the following:
  * *.agentevt.> - agent events streamed from workloads
- * agentint.> - where the first token after agentint is the account ID from the workload
+ * hostint.> - where the first token after agentint is the account ID from the workload
  */
 
 const (
@@ -37,19 +37,19 @@ accounts: {
 		]
 		exports: [
 			{
-				service: agentint.>
+				service: hostint.>
 			}
 		],
 		imports: [
 			{{ range .Credentials }}
 			{
-				stream: {subject: agentint.>, account: {{ .ID }}}
+				service: {subject: agentint.{{ .ID }}.>, account: {{ .ID }}}
 			},
 			{
 				stream: {subject: agentevt.>, account: {{ .ID }}}, prefix: {{ .ID }}
 			},
 			{{ end }}
-		]	
+		]
 	},
 	{{ range .Credentials }}
 	{{ .ID }}: {
@@ -57,17 +57,26 @@ accounts: {
 		users: [
 			{nkey: "{{ .NkeyPublic }}"}
 		]
-		imports: [
-			{service: {account: nexhost, subject: agentint.{{ .ID }}.>}, to: agentint.>}
-		]
 		exports: [
-			{stream: agentint.>, accounts: [nexhost]}
-			{stream: agentevt.>, accounts: [nexhost]}
+			{
+				service: agentint.{{ .ID }}.>, accounts: [nexhost]
+			}
+			{
+				stream: agentevt.>, accounts: [nexhost]
+			}
 		]
+		imports: [
+			{
+				service: {account: nexhost, subject: hostint.{{ .ID }}.>}
+			}
+		]
+
 	},
-	{{ end }}	
+	{{ end }}
 }
 no_sys_acc: true
+debug: false
+trace: false
 `
 )
 

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -7,7 +7,6 @@ import (
 )
 
 type internalServerData struct {
-	// workloadID -> userData
 	Users             []userData
 	NexHostUserPublic string
 	NexHostUserSeed   string

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -41,21 +41,21 @@ accounts: {
 			}
 		],
 		imports: [
-			{{ range .Users }}
+			{{ range .Credentials }}
 			{
-				stream: {subject: agentevt.>, account: {{ .WorkloadID }}}, prefix: {{ .WorkloadID }}
+				stream: {subject: agentevt.>, account: {{ .ID }}}, prefix: {{ .ID }}
 			},
 			{{ end }}
 		]	
 	},
-	{{ range .Users }}
-	{{ .WorkloadID }}: {
+	{{ range .Credentials }}
+	{{ .ID }}: {
 		jetstream: true
 		users: [
 			{nkey: "{{ .NkeyPublic }}"}
 		]
 		imports: [
-			{service: {account: nexhost, subject: agentint.{{ .WorkloadID }}.>}, to: agentint.>}
+			{service: {account: nexhost, subject: agentint.{{ .ID }}.>}, to: agentint.>}
 		]
 		exports: [
 			{stream: agentevt.>, accounts: [nexhost]}

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -33,6 +33,7 @@ accounts: {
 	nexhost: {
 		jetstream: true		
 		users: [
+			{user: nex, password: pass}
 			{nkey: "{{ .NexHostUserPublic }}"}
 		]
 		exports: [
@@ -42,6 +43,9 @@ accounts: {
 		],
 		imports: [
 			{{ range .Credentials }}
+			{
+				stream: {subject: agentint.>, account: {{ .ID }}}
+			},
 			{
 				stream: {subject: agentevt.>, account: {{ .ID }}}, prefix: {{ .ID }}
 			},
@@ -58,6 +62,7 @@ accounts: {
 			{service: {account: nexhost, subject: agentint.{{ .ID }}.>}, to: agentint.>}
 		]
 		exports: [
+			{stream: agentint.>, accounts: [nexhost]}
 			{stream: agentevt.>, accounts: [nexhost]}
 		]
 	},

--- a/internal/node/internal-nats/config_template_test.go
+++ b/internal/node/internal-nats/config_template_test.go
@@ -1,0 +1,144 @@
+package internalnats
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nkeys"
+	"github.com/nats-io/nuid"
+)
+
+func TestTemplateGenerator(t *testing.T) {
+
+	data := internalServerData{
+		Users: make([]userData, 0),
+	}
+
+	hostUser, _ := nkeys.CreateUser()
+	hostPub, _ := hostUser.PublicKey()
+	hostSeed, _ := hostUser.Seed()
+
+	data.NexHostUserPublic = hostPub
+	data.NexHostUserSeed = string(hostSeed)
+
+	for i := 0; i < 10; i++ {
+		userSeed, _ := nkeys.CreateUser()
+		seed, _ := userSeed.Seed()
+		seedPub, _ := userSeed.PublicKey()
+
+		data.Users = append(data.Users, userData{
+			WorkloadID: nuid.Next(),
+			NkeySeed:   string(seed),
+			NkeyPublic: seedPub,
+		})
+	}
+
+	bytes, err := GenerateFile(slog.Default(), data)
+	if err != nil {
+		t.Fatalf("failed to render template: %s", err)
+	}
+
+	fmt.Printf("----\n%s\n----\n", string(bytes))
+
+	f, err := os.CreateTemp("", "fooconf")
+	defer os.Remove(f.Name()) // clean up
+	if _, err := f.Write(bytes); err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	opts := &server.Options{
+		JetStream: true,
+		StoreDir:  "pnats",
+		Port:      -1,
+	}
+	err = opts.ProcessConfigFile(f.Name())
+	if err != nil {
+		t.Fatalf("failed to process configuration file: %s", err)
+	}
+	s, err := server.NewServer(opts)
+	if err != nil {
+		server.PrintAndDie("nats-server: " + err.Error())
+	}
+	s.ConfigureLogger()
+	if err := server.Run(s); err != nil {
+		server.PrintAndDie(err.Error())
+	}
+	ncHost, err := nats.Connect(s.ClientURL(), nats.Nkey(data.NexHostUserPublic, func(b []byte) ([]byte, error) {
+		return hostUser.Sign(b)
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%+v\n", ncHost.Servers())
+
+	var eventWg sync.WaitGroup
+	eventWg.Add(1)
+
+	_, _ = ncHost.Subscribe("*.agentevt.>", func(msg *nats.Msg) {
+		tokens := strings.Split(msg.Subject, ".")
+		if tokens[0] == data.Users[0].WorkloadID && tokens[2] == "my_event" {
+			eventWg.Done()
+		}
+	})
+
+	_, _ = ncHost.Subscribe("agentint.>", func(msg *nats.Msg) {
+		tokens := strings.Split(msg.Subject, ".")
+		fmt.Printf("-- Replying to %s\n", msg.Subject)
+		if tokens[1] == data.Users[0].WorkloadID {
+			_ = msg.Respond([]byte{42, 42, 42})
+		}
+	})
+
+	ncUser1, err := nats.Connect(s.ClientURL(), nats.Nkey(data.Users[0].NkeyPublic, func(b []byte) ([]byte, error) {
+		priv, _ := nkeys.FromSeed([]byte(data.Users[0].NkeySeed))
+		return priv.Sign(b)
+	}))
+
+	// host account should be able to see all of these
+	_ = ncUser1.Publish("agentevt.my_event", []byte{1, 2, 3})
+	eventWg.Wait()
+
+	res, err := ncUser1.Request("agentint.my.service", []byte{1, 1, 1}, 1*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(res.Data, []byte{42, 42, 42}) {
+		t.Fatalf("Failed to get reply from exported service: %+v", res.Data)
+	}
+
+	_, err = nats.Connect(s.ClientURL())
+	if err == nil {
+		t.Fatal("Was supposed to fail to connect with unauthorized user but didn't")
+	}
+
+	go s.WaitForShutdown()
+
+}
+
+func startNatsServer(t *testing.T) (func(), *nats.Conn) {
+	t.Helper()
+	opts := &server.Options{
+		JetStream: true,
+		Port:      -1,
+	}
+	s, err := server.NewServer(opts)
+	if err != nil {
+		server.PrintAndDie("nats-server: " + err.Error())
+	}
+	s.ConfigureLogger()
+	if err := server.Run(s); err != nil {
+		server.PrintAndDie(err.Error())
+	}
+
+	go s.WaitForShutdown()
+	nc, _ := nats.Connect(s.ClientURL())
+	return s.Shutdown, nc
+}

--- a/internal/node/internal-nats/config_template_test.go
+++ b/internal/node/internal-nats/config_template_test.go
@@ -49,6 +49,9 @@ func TestTemplateGenerator(t *testing.T) {
 	fmt.Printf("----\n%s\n----\n", string(bytes))
 
 	f, err := os.CreateTemp("", "fooconf")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %s", err)
+	}
 	defer os.Remove(f.Name()) // clean up
 	if _, err := f.Write(bytes); err != nil {
 		t.Fatalf("%s", err)
@@ -101,6 +104,9 @@ func TestTemplateGenerator(t *testing.T) {
 		priv, _ := nkeys.FromSeed([]byte(data.Users[0].NkeySeed))
 		return priv.Sign(b)
 	}))
+	if err != nil {
+		t.Fatalf("Failed to connect as user: %s", err)
+	}
 
 	// host account should be able to see all of these
 	_ = ncUser1.Publish("agentevt.my_event", []byte{1, 2, 3})
@@ -121,24 +127,4 @@ func TestTemplateGenerator(t *testing.T) {
 
 	go s.WaitForShutdown()
 
-}
-
-func startNatsServer(t *testing.T) (func(), *nats.Conn) {
-	t.Helper()
-	opts := &server.Options{
-		JetStream: true,
-		Port:      -1,
-	}
-	s, err := server.NewServer(opts)
-	if err != nil {
-		server.PrintAndDie("nats-server: " + err.Error())
-	}
-	s.ConfigureLogger()
-	if err := server.Run(s); err != nil {
-		server.PrintAndDie(err.Error())
-	}
-
-	go s.WaitForShutdown()
-	nc, _ := nats.Connect(s.ClientURL())
-	return s.Shutdown, nc
 }

--- a/internal/node/internal-nats/config_template_test.go
+++ b/internal/node/internal-nats/config_template_test.go
@@ -100,7 +100,7 @@ func TestTemplateGenerator(t *testing.T) {
 		}
 	})
 
-	_, _ = ncHost.Subscribe("agentint.>", func(msg *nats.Msg) {
+	_, _ = ncHost.Subscribe("hostint.>", func(msg *nats.Msg) {
 		tokens := strings.Split(msg.Subject, ".")
 		fmt.Printf("-- Replying to %s\n", msg.Subject)
 		if tokens[1] == data.Credentials[id].ID {
@@ -120,7 +120,7 @@ func TestTemplateGenerator(t *testing.T) {
 	_ = ncUser1.Publish("agentevt.my_event", []byte{1, 2, 3})
 	eventWg.Wait()
 
-	res, err := ncUser1.Request("agentint.my.service", []byte{1, 1, 1}, 1*time.Second)
+	res, err := ncUser1.Request(fmt.Sprintf("hostint.%s.service", id), []byte{1, 1, 1}, 1*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/node/internal-nats/config_template_test.go
+++ b/internal/node/internal-nats/config_template_test.go
@@ -19,7 +19,8 @@ import (
 func TestTemplateGenerator(t *testing.T) {
 
 	data := internalServerData{
-		Users: make([]userData, 0),
+		Credentials: map[string]*credentials{},
+		Users:       make([]credentials, 0),
 	}
 
 	hostUser, _ := nkeys.CreateUser()
@@ -34,14 +35,14 @@ func TestTemplateGenerator(t *testing.T) {
 		seed, _ := userSeed.Seed()
 		seedPub, _ := userSeed.PublicKey()
 
-		data.Users = append(data.Users, userData{
+		data.Users = append(data.Users, credentials{
 			WorkloadID: nuid.Next(),
 			NkeySeed:   string(seed),
 			NkeyPublic: seedPub,
 		})
 	}
 
-	bytes, err := GenerateFile(slog.Default(), data)
+	bytes, err := GenerateTemplate(slog.Default(), data)
 	if err != nil {
 		t.Fatalf("failed to render template: %s", err)
 	}

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -88,6 +88,10 @@ func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
 	return &internalServer, nil
 }
 
+func (s *InternalNatsServer) Port() int {
+	return s.lastOpts.Port
+}
+
 // Returns a user keypair that can be used to log into the internal server
 // as the given workload
 func (s *InternalNatsServer) CreateNewWorkloadUser(workloadID string) (nkeys.KeyPair, error) {
@@ -121,6 +125,10 @@ func (s *InternalNatsServer) CreateNewWorkloadUser(workloadID string) (nkeys.Key
 	//s.lastOpts = updated
 
 	return userPair, nil
+}
+
+func (s *InternalNatsServer) ClientURL() string {
+	return s.ncInternal.ConnectedUrl()
 }
 
 func (s *InternalNatsServer) Connection() *nats.Conn {

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -50,6 +50,9 @@ func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
 	data.NexHostUserSeed = string(hostSeed)
 
 	opts, err := updateNatsOptions(opts, log, data)
+	if err != nil {
+		return nil, err
+	}
 
 	s, err := server.NewServer(opts)
 	if err != nil {
@@ -178,6 +181,7 @@ func (s *InternalNatsServer) FindWorkload(workloadId string) (*userData, error) 
 }
 
 func ensureWorkloadObjectStore(nc *nats.Conn) (jetstream.ObjectStore, error) {
+	var err error
 	ctx, cancelF := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancelF()
 
@@ -195,6 +199,9 @@ func ensureWorkloadObjectStore(nc *nats.Conn) (jetstream.ObjectStore, error) {
 				Description: "Cache for workload images to be executed by agent",
 				Storage:     jetstream.MemoryStorage,
 			})
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			return nil, err
 		}
@@ -214,6 +221,9 @@ func updateNatsOptions(opts *server.Options, log *slog.Logger, data internalServ
 		f, err = os.CreateTemp("", "internalconf")
 	} else {
 		f, err = os.Create(opts.ConfigFile)
+	}
+	if err != nil {
+		return nil, err
 	}
 	defer os.Remove(f.Name()) // clean up
 

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -63,7 +63,7 @@ func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
 	}
 
 	// uncomment this if you want internal NATS logs emitted
-	//s.ConfigureLogger()
+	// s.ConfigureLogger()
 
 	if err := server.Run(s); err != nil {
 		server.PrintAndDie(err.Error())
@@ -72,7 +72,7 @@ func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
 
 	// This connection uses the `nexhost` account, specifically provisioned for the node
 	ncInternal, err := nats.Connect(s.ClientURL(), nats.Nkey(data.NexHostUserPublic, func(b []byte) ([]byte, error) {
-		log.Debug("Attempting to sign NATS server nonce for internal workload user connection", slog.String("public_key", data.NexHostUserPublic))
+		log.Debug("Attempting to sign NATS server nonce for internal host connection", slog.String("public_key", data.NexHostUserPublic))
 		return hostUser.Sign(b)
 	}))
 	if err != nil {

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -95,6 +95,10 @@ func (s *InternalNatsServer) Port() int {
 	return s.lastOpts.Port
 }
 
+func (s *InternalNatsServer) Subsz(opts *server.SubszOptions) (*server.Subsz, error) {
+	return s.server.Subsz(opts)
+}
+
 // Returns a user keypair that can be used to log into the internal server
 // as the given workload
 func (s *InternalNatsServer) CreateNewWorkloadUser(workloadID string) (nkeys.KeyPair, error) {

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -188,10 +188,6 @@ func (s *InternalNatsServer) Connection() *nats.Conn {
 }
 
 func (s *InternalNatsServer) Shutdown() {
-	for id, _ := range s.serverConfigData.Credentials {
-		delete(s.serverConfigData.Credentials, id)
-	}
-
 	s.server.Shutdown()
 	s.server.WaitForShutdown()
 }

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -25,10 +25,10 @@ const (
 
 type InternalNatsServer struct {
 	ncInternal       *nats.Conn
-	serverConfigData internalServerData
 	log              *slog.Logger
 	lastOpts         *server.Options
 	server           *server.Server
+	serverConfigData internalServerData
 }
 
 func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
@@ -41,10 +41,7 @@ func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
 	}
 
 	data := internalServerData{
-		Credentials:       map[string]*credentials{},
-		NexHostUserPublic: "",
-		NexHostUserSeed:   "",
-		Users:             make([]credentials, 0),
+		Credentials: map[string]*credentials{},
 	}
 
 	hostUser, _ := nkeys.CreateUser()
@@ -118,7 +115,7 @@ func (s *InternalNatsServer) CreateNewWorkloadUser(workloadID string) (nkeys.Key
 	creds := &credentials{
 		NkeySeed:   string(seed),
 		NkeyPublic: pk,
-		WorkloadID: workloadID,
+		ID:         workloadID,
 	}
 	s.serverConfigData.Credentials[workloadID] = creds
 

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -1,0 +1,244 @@
+package internalnats
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/nats-io/nkeys"
+)
+
+const (
+	workloadCacheBucketName = "NEXCACHE"
+	workloadCacheFileKey    = "workload"
+)
+
+type InternalNatsServer struct {
+	ncInternal       *nats.Conn
+	serverConfigData internalServerData
+	log              *slog.Logger
+	lastOpts         *server.Options
+	server           *server.Server
+}
+
+func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
+	opts := &server.Options{
+		JetStream: true,
+		StoreDir:  "pnats",
+		Port:      -1,
+		// Uncomment this when you want internal NATS server logs to be suppressed
+		// NoLog: true
+	}
+
+	data := internalServerData{
+		Users:             make([]userData, 0),
+		NexHostUserPublic: "",
+		NexHostUserSeed:   "",
+	}
+	hostUser, _ := nkeys.CreateUser()
+	hostPub, _ := hostUser.PublicKey()
+	hostSeed, _ := hostUser.Seed()
+
+	data.NexHostUserPublic = hostPub
+	data.NexHostUserSeed = string(hostSeed)
+
+	opts, err := updateNatsOptions(opts, log, data)
+
+	s, err := server.NewServer(opts)
+	if err != nil {
+		server.PrintAndDie("nats-server: " + err.Error())
+		return nil, err
+	}
+
+	s.ConfigureLogger()
+	if err := server.Run(s); err != nil {
+		server.PrintAndDie(err.Error())
+		return nil, err
+	}
+
+	ncInternal, err := nats.Connect(s.ClientURL(), nats.Nkey(data.NexHostUserPublic, func(b []byte) ([]byte, error) {
+		return hostUser.Sign(b)
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	opts.Port = getPort(s.ClientURL())
+
+	internalServer := InternalNatsServer{
+		ncInternal:       ncInternal,
+		serverConfigData: data,
+		log:              log,
+		lastOpts:         opts,
+		server:           s,
+	}
+
+	go s.WaitForShutdown()
+
+	return &internalServer, nil
+}
+
+// Returns a user keypair that can be used to log into the internal server
+// as the given workload
+func (s *InternalNatsServer) CreateNewWorkloadUser(workloadID string) (nkeys.KeyPair, error) {
+	userPair, err := nkeys.CreateUser()
+	if err != nil {
+		return nil, err
+	}
+	pk, _ := userPair.PublicKey()
+	seed, _ := userPair.Seed()
+	s.serverConfigData.Users = append(s.serverConfigData.Users, userData{
+		WorkloadID: workloadID,
+		NkeySeed:   string(seed),
+		NkeyPublic: pk,
+	})
+
+	opts := &server.Options{
+		JetStream:  true,
+		StoreDir:   "pnats",
+		Port:       s.lastOpts.Port,
+		ConfigFile: s.lastOpts.ConfigFile,
+	}
+
+	updated, err := updateNatsOptions(opts, s.log, s.serverConfigData)
+	if err != nil {
+		return nil, err
+	}
+	err = s.server.ReloadOptions(updated)
+	if err != nil {
+		return nil, err
+	}
+	//s.lastOpts = updated
+
+	return userPair, nil
+}
+
+func (s *InternalNatsServer) Connection() *nats.Conn {
+	return s.ncInternal
+}
+
+func (s *InternalNatsServer) Shutdown() {
+	s.server.Shutdown()
+}
+
+func (s *InternalNatsServer) WaitForShutdown() {
+	s.server.WaitForShutdown()
+}
+
+func (s *InternalNatsServer) StoreFileForWorkload(workloadId string, bytes []byte) error {
+	ctx, cancelF := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelF()
+
+	ud, err := s.FindWorkload(workloadId)
+	if err != nil {
+		return err
+	}
+	nc, err := s.ConnectionForUser(ud)
+	if err != nil {
+		return err
+	}
+	bucket, err := ensureWorkloadObjectStore(nc)
+	if err != nil {
+		return err
+	}
+
+	_, err = bucket.PutBytes(ctx, workloadCacheFileKey, bytes)
+	return err
+}
+
+func (s *InternalNatsServer) ConnectionForUser(ud *userData) (*nats.Conn, error) {
+	pair, err := nkeys.FromSeed([]byte(ud.NkeySeed))
+	if err != nil {
+		return nil, err
+	}
+	nc, err := nats.Connect(s.server.ClientURL(), nats.Nkey(ud.NkeyPublic, func(b []byte) ([]byte, error) {
+		return pair.Sign(b)
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return nc, nil
+}
+
+func (s *InternalNatsServer) FindWorkload(workloadId string) (*userData, error) {
+	for _, v := range s.serverConfigData.Users {
+		if v.WorkloadID == workloadId {
+			return &v, nil
+		}
+	}
+
+	return nil, errors.New("No such workload")
+}
+
+func ensureWorkloadObjectStore(nc *nats.Conn) (jetstream.ObjectStore, error) {
+	ctx, cancelF := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelF()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return nil, err
+	}
+	var bucket jetstream.ObjectStore
+
+	bucket, err = js.ObjectStore(ctx, workloadCacheBucketName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			bucket, err = js.CreateObjectStore(ctx, jetstream.ObjectStoreConfig{
+				Bucket:      workloadCacheBucketName,
+				Description: "Cache for workload images to be executed by agent",
+				Storage:     jetstream.MemoryStorage,
+			})
+		} else {
+			return nil, err
+		}
+	}
+	return bucket, nil
+}
+
+func updateNatsOptions(opts *server.Options, log *slog.Logger, data internalServerData) (*server.Options, error) {
+	bytes, err := GenerateFile(log, data)
+	if err != nil {
+		log.Error("Failed to generate internal nats server config file", slog.Any("error", err))
+		return nil, err
+	}
+
+	var f *os.File
+	if len(opts.ConfigFile) == 0 {
+		f, err = os.CreateTemp("", "internalconf")
+	} else {
+		f, err = os.Create(opts.ConfigFile)
+	}
+	defer os.Remove(f.Name()) // clean up
+
+	if _, err := f.Write(bytes); err != nil {
+		log.Error("Failed to write internal nats server config file", slog.Any("error", err))
+		return nil, err
+	}
+
+	err = opts.ProcessConfigFile(f.Name())
+	if err != nil {
+		log.Error("Failed to process configuration file", slog.Any("error", err))
+		return nil, err
+	}
+
+	return opts, nil
+}
+
+func getPort(clientUrl string) int {
+	u, err := url.Parse(clientUrl)
+	if err != nil {
+		return -1
+	}
+	res, err := strconv.Atoi(u.Port())
+	if err != nil {
+		return -1
+	}
+	return res
+}

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -104,6 +104,7 @@ func (s *InternalNatsServer) Subsz(opts *server.SubszOptions) (*server.Subsz, er
 func (s *InternalNatsServer) CreateNewWorkloadUser(workloadID string) (nkeys.KeyPair, error) {
 	userPair, err := nkeys.CreateUser()
 	if err != nil {
+		s.log.Error("Failed to create nkey user", slog.Any("error", err))
 		return nil, err
 	}
 	pk, _ := userPair.PublicKey()
@@ -124,20 +125,26 @@ func (s *InternalNatsServer) CreateNewWorkloadUser(workloadID string) (nkeys.Key
 
 	updated, err := updateNatsOptions(opts, s.log, s.serverConfigData)
 	if err != nil {
+		s.log.Error("Failed to update NATS options in internal server", slog.Any("error", err))
 		return nil, err
 	}
 	err = s.server.ReloadOptions(updated)
 	if err != nil {
+		s.log.Error("Failed to reload NATS internal server options", slog.Any("error", err))
 		return nil, err
 	}
 
 	nc, err := s.ConnectionForUser(&ud)
 	if err != nil {
+		s.log.Error("Failed to obtain connection for workload-user", slog.Any("error", err))
 		return nil, err
 	}
 
 	_, err = ensureWorkloadObjectStore(nc)
 	if err != nil {
+		s.log.Error("Failed to create or locate the workload object store in internal NATS server",
+			slog.Any("error", err),
+		)
 		return nil, err
 	}
 

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -36,8 +36,9 @@ func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
 		JetStream: true,
 		StoreDir:  path.Join(os.TempDir(), defaultInternalNatsStoreDir),
 		Port:      -1,
-		// Uncomment this when you want internal NATS server logs to be suppressed
-		// NoLog: true
+		// Debug:     true,
+		// Trace:     true,
+		// NoLog:     true,
 	}
 
 	data := internalServerData{

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -60,12 +60,15 @@ func NewInternalNatsServer(log *slog.Logger) (*InternalNatsServer, error) {
 		return nil, err
 	}
 
-	s.ConfigureLogger()
+	// uncomment this if you want internal NATS logs emitted
+	//s.ConfigureLogger()
+
 	if err := server.Run(s); err != nil {
 		server.PrintAndDie(err.Error())
 		return nil, err
 	}
 
+	// This connection uses the `nexhost` account, specifically provisioned for the node
 	ncInternal, err := nats.Connect(s.ClientURL(), nats.Nkey(data.NexHostUserPublic, func(b []byte) ([]byte, error) {
 		return hostUser.Sign(b)
 	}))

--- a/internal/node/internal-nats/internal_nats_server_test.go
+++ b/internal/node/internal-nats/internal_nats_server_test.go
@@ -31,7 +31,7 @@ func TestInternalNatsServer(t *testing.T) {
 
 	workloadId := nuid.Next()
 
-	keypair, err := server.CreateNewWorkloadUser(workloadId)
+	keypair, err := server.CreateCredentials(workloadId)
 	if err != nil {
 		t.Fatalf("Should have been able to add a workload user but couldn't: %s", err)
 	}
@@ -49,7 +49,7 @@ func TestInternalNatsServer(t *testing.T) {
 	}
 
 	workloadId2 := nuid.Next()
-	keypair2, err := server.CreateNewWorkloadUser(workloadId2)
+	keypair2, err := server.CreateCredentials(workloadId2)
 	if err != nil {
 		t.Fatalf("Should have been able to add a workload user but couldn't: %s", err)
 	}
@@ -79,7 +79,7 @@ func TestInternalNatsServerFileCache(t *testing.T) {
 
 	workloadId := nuid.Next()
 
-	keypair, err := server.CreateNewWorkloadUser(workloadId)
+	keypair, err := server.CreateCredentials(workloadId)
 	if err != nil {
 		t.Fatalf("Should have been able to add a workload user but couldn't: %s", err)
 	}

--- a/internal/node/internal-nats/internal_nats_server_test.go
+++ b/internal/node/internal-nats/internal_nats_server_test.go
@@ -1,0 +1,98 @@
+package internalnats
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/nats-io/nuid"
+)
+
+func TestInternalNatsServer(t *testing.T) {
+
+	server, err := NewInternalNatsServer(slog.Default())
+	if err != nil {
+		t.Fatalf("Failed to create internal nats server: %s", err)
+	}
+	fmt.Printf("Internal server on %s\n", server.Connection().Servers()[0])
+
+	workloadId := nuid.Next()
+
+	keypair, err := server.CreateNewWorkloadUser(workloadId)
+	if err != nil {
+		t.Fatalf("Should have been able to add a workload user but couldn't: %s", err)
+	}
+	pk, _ := keypair.PublicKey()
+	seed, _ := keypair.Seed()
+	fmt.Printf("New workload user: %s %s\n", pk, string(seed))
+
+	// log in as the new workload
+	_, err = nats.Connect(server.Connection().Servers()[0], nats.Nkey(pk, func(b []byte) ([]byte, error) {
+		return keypair.Sign(b)
+	}))
+
+	if err != nil {
+		t.Fatalf("Couldn't connect to the internal server as a workload: %s", err)
+	}
+
+	workloadId2 := nuid.Next()
+	keypair2, err := server.CreateNewWorkloadUser(workloadId2)
+	if err != nil {
+		t.Fatalf("Should have been able to add a workload user but couldn't: %s", err)
+	}
+	pk2, _ := keypair2.PublicKey()
+	seed2, _ := keypair2.Seed()
+	fmt.Printf("New workload user: %s %s\n", pk2, string(seed2))
+
+	// log in as the new workload
+	_, err = nats.Connect(server.Connection().Servers()[0], nats.Nkey(pk2, func(b []byte) ([]byte, error) {
+		return keypair2.Sign(b)
+	}))
+
+	if err != nil {
+		t.Fatalf("Couldn't connect to the internal server as a workload: %s", err)
+	}
+}
+
+// With the new security system, all agents will simply pull their workload binary from
+// the NEXCACHE bucket in their account, with the key of 'workload'
+func TestInternalNatsServerFileCache(t *testing.T) {
+	ctx := context.Background()
+	server, err := NewInternalNatsServer(slog.Default())
+	if err != nil {
+		t.Fatalf("Failed to create internal nats server: %s", err)
+	}
+	fmt.Printf("Internal server on %s\n", server.Connection().Servers()[0])
+
+	workloadId := nuid.Next()
+
+	keypair, err := server.CreateNewWorkloadUser(workloadId)
+	if err != nil {
+		t.Fatalf("Should have been able to add a workload user but couldn't: %s", err)
+	}
+	pk, _ := keypair.PublicKey()
+	seed, _ := keypair.Seed()
+	fmt.Printf("New workload user: %s %s\n", pk, string(seed))
+
+	err = server.StoreFileForWorkload(workloadId, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	if err != nil {
+		t.Fatalf("Should have gotten no error but didn't: %s", err)
+	}
+
+	ud, _ := server.FindWorkload(workloadId)
+	userCn, _ := server.ConnectionForUser(ud)
+	js, _ := jetstream.New(userCn)
+	bucket, _ := js.ObjectStore(ctx, workloadCacheBucketName)
+	workload, err := bucket.GetBytes(ctx, workloadCacheFileKey)
+	if err != nil {
+		t.Fatalf("Should have queried the workload bytes, but got error instead: %s", err)
+	}
+
+	if !slices.Equal(workload, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}) {
+		t.Fatalf("File bytes did not round trip properly, got %+v", workload)
+	}
+}

--- a/internal/node/internal-nats/internal_nats_server_test.go
+++ b/internal/node/internal-nats/internal_nats_server_test.go
@@ -87,13 +87,13 @@ func TestInternalNatsServerFileCache(t *testing.T) {
 	seed, _ := keypair.Seed()
 	fmt.Printf("New workload user: %s %s\n", pk, string(seed))
 
-	err = server.StoreFileForWorkload(workloadId, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	err = server.StoreFileForID(workloadId, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
 	if err != nil {
 		t.Fatalf("Should have gotten no error but didn't: %s", err)
 	}
 
-	ud, _ := server.FindWorkload(workloadId)
-	userCn, _ := server.ConnectionForUser(ud)
+	ud, _ := server.FindCredentials(workloadId)
+	userCn, _ := server.ConnectionWithCredentials(ud)
 	js, _ := jetstream.New(userCn)
 	bucket, _ := js.ObjectStore(ctx, workloadCacheBucketName)
 	workload, err := bucket.GetBytes(ctx, workloadCacheFileKey)

--- a/internal/node/internal-nats/internal_nats_server_test.go
+++ b/internal/node/internal-nats/internal_nats_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"slices"
 	"testing"
 
@@ -18,7 +19,15 @@ func TestInternalNatsServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create internal nats server: %s", err)
 	}
-	fmt.Printf("Internal server on %s\n", server.Connection().Servers()[0])
+	serverUrl := server.Connection().Servers()[0]
+	sUrl, err := url.Parse(serverUrl)
+	if err != nil {
+		t.Fatalf("Should have a valid URL from the server but didn't: %s", err)
+	}
+	p := server.Port()
+	if fmt.Sprintf("%d", p) != sUrl.Port() {
+		t.Fatalf("Port number from options doesn't match what's running: %d %s", p, sUrl.Port())
+	}
 
 	workloadId := nuid.Next()
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -352,11 +352,11 @@ func (n *Node) startHostServicesConnection(defaultConnection *nats.Conn) error {
 
 func (n *Node) startInternalNATS() error {
 	var err error
-
 	n.natsint, err = internalnats.NewInternalNatsServer(n.log)
 	if err != nil {
 		return err
 	}
+
 	p := n.natsint.Port()
 	n.config.InternalNodePort = &p
 	n.ncint = n.natsint.Connection()

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -324,18 +324,18 @@ func (n *Node) startPublicNATS() error {
 }
 
 func (n *Node) handleAutostarts() {
-	var agentClient *agentapi.AgentClient
-	var err error
-
-	for agentClient == nil {
-		agentClient, err = n.manager.SelectRandomAgent()
-		if err != nil {
-			n.log.Warn("Failed to resolve agent for autostart", slog.String("error", err.Error()))
-			time.Sleep(25 * time.Millisecond)
-		}
-	}
-
 	for _, autostart := range n.config.AutostartConfiguration.Workloads {
+		var agentClient *agentapi.AgentClient
+		var err error
+
+		for agentClient == nil {
+			agentClient, err = n.manager.SelectRandomAgent()
+			if err != nil {
+				n.log.Warn("Failed to resolve agent for autostart", slog.String("error", err.Error()))
+				time.Sleep(25 * time.Millisecond)
+			}
+		}
+
 		request, err := controlapi.NewDeployRequest(
 			controlapi.Argv(autostart.Argv),
 			controlapi.Location(autostart.Location),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -62,10 +62,6 @@ type Node struct {
 	natspub *server.Server
 	nc      *nats.Conn
 
-	// natsint        *internalnats.InternalNatsServer
-	// ncint          *nats.Conn
-	ncHostServices *nats.Conn
-
 	startedAt time.Time
 	telemetry *observability.Telemetry
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -521,8 +521,13 @@ func (n *Node) validateConfig() error {
 func (n *Node) shutdown() {
 	if atomic.AddUint32(&n.closing, 1) == 1 {
 		n.log.Debug("shutting down")
-		_ = n.api.Drain()
-		_ = n.manager.Stop()
+		if n.api != nil {
+			_ = n.api.Drain()
+		}
+
+		if n.manager != nil {
+			_ = n.manager.Stop()
+		}
 
 		if !n.startedAt.IsZero() {
 			_ = n.publishNodeStopped()

--- a/internal/node/nodeproxy.go
+++ b/internal/node/nodeproxy.go
@@ -38,14 +38,6 @@ func (n *NodeProxy) NodeConfiguration() *models.NodeConfiguration {
 	return n.n.config
 }
 
-func (n *NodeProxy) InternalNATS() *internalnats.InternalNatsServer {
-	return n.n.natsint
-}
-
-func (n *NodeProxy) InternalNATSConn() *nats.Conn {
-	return n.n.ncint
-}
-
 func (n *NodeProxy) Telemetry() *observability.Telemetry {
 	return n.n.telemetry
 }
@@ -66,8 +58,12 @@ func (m *WorkloadManagerProxy) NodeConfiguration() *models.NodeConfiguration {
 	return m.m.config
 }
 
+func (m *WorkloadManagerProxy) InternalNATS() *internalnats.InternalNatsServer {
+	return m.m.natsint
+}
+
 func (m *WorkloadManagerProxy) InternalNATSConn() *nats.Conn {
-	return m.m.ncInternal
+	return m.m.ncint
 }
 
 func (m *WorkloadManagerProxy) Telemetry() *observability.Telemetry {

--- a/internal/node/nodeproxy.go
+++ b/internal/node/nodeproxy.go
@@ -3,9 +3,9 @@ package nexnode
 import (
 	"log/slog"
 
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/synadia-io/nex/internal/models"
+	internalnats "github.com/synadia-io/nex/internal/node/internal-nats"
 	"github.com/synadia-io/nex/internal/node/observability"
 	"github.com/synadia-io/nex/internal/node/processmanager"
 )
@@ -38,7 +38,7 @@ func (n *NodeProxy) NodeConfiguration() *models.NodeConfiguration {
 	return n.n.config
 }
 
-func (n *NodeProxy) InternalNATS() *server.Server {
+func (n *NodeProxy) InternalNATS() *internalnats.InternalNatsServer {
 	return n.n.natsint
 }
 

--- a/internal/node/processmanager/firecracker_procman.go
+++ b/internal/node/processmanager/firecracker_procman.go
@@ -48,10 +48,11 @@ func NewFirecrackerProcessManager(
 ) (*FirecrackerProcessManager, error) {
 
 	return &FirecrackerProcessManager{
-		config: config,
-		t:      telemetry,
-		log:    log,
-		ctx:    ctx,
+		config:  config,
+		intNats: intnats,
+		t:       telemetry,
+		log:     log,
+		ctx:     ctx,
 
 		allVMs:         make(map[string]*runningFirecracker),
 		warmVMs:        make(chan *runningFirecracker, config.MachinePoolSize),

--- a/internal/node/processmanager/firecracker_procman.go
+++ b/internal/node/processmanager/firecracker_procman.go
@@ -134,7 +134,7 @@ func (f *FirecrackerProcessManager) Start(delegate ProcessDelegate) error {
 
 	defer func() {
 		if r := recover(); r != nil {
-			f.log.Debug(fmt.Sprintf("recovered: %s", r))
+			f.log.Debug(fmt.Sprintf("firecracker process manager recovered from failure: %s", r))
 		}
 	}()
 
@@ -164,6 +164,7 @@ func (f *FirecrackerProcessManager) Start(delegate ProcessDelegate) error {
 			workloadKey, err := f.intNats.CreateNewWorkloadUser(vm.vmmID)
 			if err != nil {
 				f.log.Error("Failed to create workload user", slog.Any("err", err))
+				continue
 			}
 			workloadSeed, _ := workloadKey.Seed()
 

--- a/internal/node/processmanager/firecracker_procman.go
+++ b/internal/node/processmanager/firecracker_procman.go
@@ -162,7 +162,7 @@ func (f *FirecrackerProcessManager) Start(delegate ProcessDelegate) error {
 				continue
 			}
 
-			workloadKey, err := f.intNats.CreateNewWorkloadUser(vm.vmmID)
+			workloadKey, err := f.intNats.CreateCredentials(vm.vmmID)
 			if err != nil {
 				f.log.Error("Failed to create workload user", slog.Any("err", err))
 				continue

--- a/internal/node/processmanager/process_mgr_linux.go
+++ b/internal/node/processmanager/process_mgr_linux.go
@@ -7,21 +7,24 @@ import (
 	"log/slog"
 
 	"github.com/synadia-io/nex/internal/models"
+	internalnats "github.com/synadia-io/nex/internal/node/internal-nats"
 	"github.com/synadia-io/nex/internal/node/observability"
 )
 
 // Initialize an appropriate agent process manager instance based on the sandbox config value
 func NewProcessManager(
+	intNats *internalnats.InternalNatsServer,
 	log *slog.Logger,
 	config *models.NodeConfiguration,
 	telemetry *observability.Telemetry,
 	ctx context.Context,
 ) (ProcessManager, error) {
+
 	if config.NoSandbox {
 		log.Warn("⚠️  Sandboxing has been disabled! Workloads are spawned directly by agents")
 		log.Warn("⚠️  Do not run untrusted workloads in this mode!")
-		return NewSpawningProcessManager(log, config, telemetry, ctx)
+		return NewSpawningProcessManager(intNats, log, config, telemetry, ctx)
 	}
 
-	return NewFirecrackerProcessManager(log, config, telemetry, ctx)
+	return NewFirecrackerProcessManager(intNats, log, config, telemetry, ctx)
 }

--- a/internal/node/processmanager/process_mgr_windows.go
+++ b/internal/node/processmanager/process_mgr_windows.go
@@ -7,15 +7,17 @@ import (
 	"log/slog"
 
 	"github.com/synadia-io/nex/internal/models"
+	internalnats "github.com/synadia-io/nex/internal/node/internal-nats"
 	"github.com/synadia-io/nex/internal/node/observability"
 )
 
 // Initialize an appropriate agent process manager instance based on the sandbox config value
 func NewProcessManager(
+	intNats *internalnats.InternalNatsServer,
 	log *slog.Logger,
 	config *models.NodeConfiguration,
 	telemetry *observability.Telemetry,
 	ctx context.Context,
 ) (ProcessManager, error) {
-	return NewSpawningProcessManager(log, config, telemetry, ctx)
+	return NewSpawningProcessManager(intNats, log, config, telemetry, ctx)
 }

--- a/internal/node/processmanager/spawn_procman.go
+++ b/internal/node/processmanager/spawn_procman.go
@@ -230,6 +230,7 @@ func (s *SpawningProcessManager) spawn() (*spawnedProcess, error) {
 		// can't use the CNI host because we don't use it in no-sandbox mode
 		"NEX_NODE_NATS_HOST=0.0.0.0",
 		fmt.Sprintf("NEX_NODE_NATS_PORT=%d", *s.config.InternalNodePort),
+		// TODO: supply the nex node nkey seed for security
 	)
 
 	cmd.Stderr = &procLogEmitter{workloadID: workloadID, log: s.log.WithGroup(workloadID), stderr: true}

--- a/internal/node/processmanager/spawn_procman.go
+++ b/internal/node/processmanager/spawn_procman.go
@@ -227,7 +227,7 @@ func (s *SpawningProcessManager) spawn() (*spawnedProcess, error) {
 	id := xid.New()
 	workloadID := id.String()
 
-	kp, err := s.intNats.CreateNewWorkloadUser(workloadID)
+	kp, err := s.intNats.CreateCredentials(workloadID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/services.go
+++ b/internal/node/services.go
@@ -8,6 +8,7 @@ import (
 	hs "github.com/synadia-io/nex/host-services"
 	"github.com/synadia-io/nex/host-services/builtins"
 	"github.com/synadia-io/nex/internal/models"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const hostServiceHTTP = "http"
@@ -19,39 +20,35 @@ const hostServiceObjectStore = "objectstore"
 // exposed to workloads by way of the agent which makes RPC calls
 // via the internal NATS connection
 type HostServices struct {
+	config         *models.HostServicesConfig
 	log            *slog.Logger
-	mgr            *WorkloadManager
 	ncHostServices *nats.Conn
 	ncint          *nats.Conn
-
-	hsServer *hs.HostServicesServer
-	config   *models.HostServicesConfig
+	server         *hs.HostServicesServer
 }
 
 func NewHostServices(
-	mgr *WorkloadManager,
 	ncint *nats.Conn,
 	ncHostServices *nats.Conn,
 	config *models.HostServicesConfig,
 	log *slog.Logger,
+	tracer trace.Tracer,
 ) *HostServices {
 	return &HostServices{
-		log:            log,
-		mgr:            mgr,
-		ncHostServices: ncHostServices,
 		config:         config,
+		log:            log,
+		ncHostServices: ncHostServices,
 		ncint:          ncint,
 		// ‼️ It cannot be overstated how important it is that the host services server
 		// be given the -internal- NATS connection and -not- the external/control one
 		//
 		// Sincerely,
 		//     Someone who lost a day of troubleshooting
-		hsServer: hs.NewHostServicesServer(ncint, log, mgr.t.Tracer),
+		server: hs.NewHostServicesServer(ncint, log, tracer),
 	}
 }
 
 func (h *HostServices) init() error {
-
 	if httpConfig, ok := h.config.Services[hostServiceHTTP]; ok {
 		if httpConfig.Enabled {
 			http, err := builtins.NewHTTPService(h.ncHostServices, h.log)
@@ -61,12 +58,14 @@ func (h *HostServices) init() error {
 			} else {
 				h.log.Debug("initialized http host service")
 			}
-			err = h.hsServer.AddService(hostServiceHTTP, http, httpConfig.Configuration)
+
+			err = h.server.AddService(hostServiceHTTP, http, httpConfig.Configuration)
 			if err != nil {
 				return err
 			}
 		}
 	}
+
 	if kvConfig, ok := h.config.Services[hostServiceKeyValue]; ok {
 		if kvConfig.Enabled {
 			kv, err := builtins.NewKeyValueService(h.ncHostServices, h.log)
@@ -76,12 +75,14 @@ func (h *HostServices) init() error {
 			} else {
 				h.log.Debug("initialized key/value host service")
 			}
-			err = h.hsServer.AddService(hostServiceKeyValue, kv, kvConfig.Configuration)
+
+			err = h.server.AddService(hostServiceKeyValue, kv, kvConfig.Configuration)
 			if err != nil {
 				return err
 			}
 		}
 	}
+
 	if messagingConfig, ok := h.config.Services[hostServiceMessaging]; ok {
 		if messagingConfig.Enabled {
 			messaging, err := builtins.NewMessagingService(h.ncHostServices, h.log)
@@ -91,12 +92,14 @@ func (h *HostServices) init() error {
 			} else {
 				h.log.Debug("initialized messaging host service")
 			}
-			err = h.hsServer.AddService(hostServiceMessaging, messaging, messagingConfig.Configuration)
+
+			err = h.server.AddService(hostServiceMessaging, messaging, messagingConfig.Configuration)
 			if err != nil {
 				return err
 			}
 		}
 	}
+
 	if objectConfig, ok := h.config.Services[hostServiceObjectStore]; ok {
 		if objectConfig.Enabled {
 			object, err := builtins.NewObjectStoreService(h.ncHostServices, h.log)
@@ -106,14 +109,14 @@ func (h *HostServices) init() error {
 			} else {
 				h.log.Debug("initialized object store host service")
 			}
-			err = h.hsServer.AddService(hostServiceObjectStore, object, objectConfig.Configuration)
+
+			err = h.server.AddService(hostServiceObjectStore, object, objectConfig.Configuration)
 			if err != nil {
 				return err
 			}
 		}
 	}
 
-	h.log.Info("Host services configured", slog.Any("services", h.hsServer.Services()))
-
-	return h.hsServer.Start()
+	h.log.Info("Host services configured", slog.Any("services", h.server.Services()))
+	return h.server.Start()
 }

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -422,7 +422,7 @@ func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
 		}
 
 		// FIXME-- this should probably just live in workload manager
-		w.natsint.DestroyCredentials(id)
+		_ = w.natsint.DestroyCredentials(id)
 	}
 
 	err = w.procMan.StopProcess(id)

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -364,7 +364,6 @@ func (w *WorkloadManager) Stop() error {
 		}
 
 		w.natsint.Shutdown()
-		w.natsint.WaitForShutdown()
 		_ = os.Remove(path.Join(os.TempDir(), defaultInternalNatsStoreDir))
 	}
 
@@ -421,6 +420,9 @@ func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
 		if err != nil {
 			w.log.Warn("request to undeploy workload via internal NATS connection failed", slog.String("workload_id", id), slog.String("error", err.Error()))
 		}
+
+		// FIXME-- this should probably just live in workload manager
+		w.natsint.DestroyCredentials(id)
 	}
 
 	err = w.procMan.StopProcess(id)

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -505,7 +505,7 @@ func (w *WorkloadManager) generateTriggerHandler(workloadID string, tsub string,
 			w.t.FunctionFailedTriggers.Add(w.ctx, 1)
 			w.t.FunctionFailedTriggers.Add(w.ctx, 1, metric.WithAttributes(attribute.String("namespace", *request.Namespace)))
 			w.t.FunctionFailedTriggers.Add(w.ctx, 1, metric.WithAttributes(attribute.String("workload_name", *request.WorkloadName)))
-			_ = w.publishFunctionExecFailed(workloadID, *request.WorkloadName, tsub, err)
+			_ = w.publishFunctionExecFailed(workloadID, *request.WorkloadName, *request.Namespace, tsub, err)
 		} else if resp != nil {
 			parentSpan.SetStatus(codes.Ok, "Trigger succeeded")
 			runtimeNs := resp.Header.Get(agentapi.NexRuntimeNs)

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -139,7 +139,7 @@ func NewWorkloadManager(
 	w.hostServices = NewHostServices(w.ncint, w.ncHostServices, config.HostServicesConfiguration, w.log, w.t.Tracer)
 	err = w.hostServices.init()
 	if err != nil {
-		w.log.Warn("Failed to initialize host services.", slog.Any("err", err))
+		w.log.Warn("Failed to initialize host services", slog.Any("err", err))
 		return nil, err
 	}
 

--- a/internal/node/workload_mgr_events.go
+++ b/internal/node/workload_mgr_events.go
@@ -110,21 +110,15 @@ func (w *WorkloadManager) agentLog(workloadId string, entry agentapi.LogEntry) {
 	_ = w.nc.Publish(subject, bytes)
 }
 
-func (w *WorkloadManager) publishFunctionExecFailed(workloadId string, workload string, tsub string, origErr error) error {
-	deployRequest, err := w.procMan.Lookup(workloadId)
-	if err != nil {
-		w.log.Warn("Tried to publish function exec failed event for non-existent workload", slog.String("workload_id", workloadId))
-		return nil
-	}
-
+func (w *WorkloadManager) publishFunctionExecFailed(workloadId string, workloadName string, namespace string, tsub string, origErr error) error {
 	functionExecFailed := struct {
 		Name      string `json:"workload_name"`
 		Subject   string `json:"trigger_subject"`
 		Namespace string `json:"namespace"`
 		Error     string `json:"error"`
 	}{
-		Name:      workload,
-		Namespace: *deployRequest.Namespace,
+		Name:      workloadName,
+		Namespace: namespace,
 		Subject:   tsub,
 		Error:     origErr.Error(),
 	}
@@ -137,7 +131,7 @@ func (w *WorkloadManager) publishFunctionExecFailed(workloadId string, workload 
 	cloudevent.SetDataContentType(cloudevents.ApplicationJSON)
 	_ = cloudevent.SetData(functionExecFailed)
 
-	err = PublishCloudEvent(w.nc, *deployRequest.Namespace, cloudevent, w.log)
+	err := PublishCloudEvent(w.nc, namespace, cloudevent, w.log)
 	if err != nil {
 		return err
 	}
@@ -149,7 +143,7 @@ func (w *WorkloadManager) publishFunctionExecFailed(workloadId string, workload 
 	}
 	logBytes, _ := json.Marshal(emitLog)
 
-	subject := fmt.Sprintf("%s.%s.%s.%s.%s", LogSubjectPrefix, *deployRequest.Namespace, w.publicKey, *deployRequest.WorkloadName, workloadId)
+	subject := fmt.Sprintf("%s.%s.%s.%s.%s", LogSubjectPrefix, namespace, w.publicKey, workloadName, workloadId)
 	err = w.nc.Publish(subject, logBytes)
 	if err != nil {
 		w.log.Error("Failed to publish function exec failed log", slog.Any("err", err))

--- a/spec/node_linux_test.go
+++ b/spec/node_linux_test.go
@@ -320,14 +320,6 @@ var _ = Describe("nex node", func() {
 						Expect(nodeProxy.NodeConfiguration()).ToNot(BeNil()) // FIXME-- assert that it is === to the current nex node config JSON
 					})
 
-					It("should initialize an internal NATS server for private communication between running VMs and the host", func(ctx SpecContext) {
-						Expect(nodeProxy.InternalNATS()).ToNot(BeNil())
-					})
-
-					It("should initialize a connection to the internal NATS server", func(ctx SpecContext) {
-						Expect(nodeProxy.InternalNATSConn()).ToNot(BeNil())
-					})
-
 					It("should initialize a machine manager to manage firecracker VMs and communicate with running agents", func(ctx SpecContext) {
 						Expect(nodeProxy.WorkloadManager()).ToNot(BeNil())
 					})
@@ -434,8 +426,12 @@ var _ = Describe("nex node", func() {
 							Expect(managerProxy.NodeConfiguration()).To(Equal(nodeProxy.NodeConfiguration())) // FIXME-- assert that it is === to the current nex node config JSON
 						})
 
-						It("should receive a reference to the internal NATS server connection", func(ctx SpecContext) {
-							Expect(managerProxy.InternalNATSConn()).To(Equal(nodeProxy.InternalNATSConn()))
+						It("should initialize an internal NATS server for private communication between running VMs and the host", func(ctx SpecContext) {
+							Expect(managerProxy.InternalNATS()).ToNot(BeNil())
+						})
+
+						It("should initialize a connection to the internal NATS server", func(ctx SpecContext) {
+							Expect(managerProxy.InternalNATSConn()).ToNot(BeNil())
 						})
 
 						It("should receive a reference to the telemetry instance", func(ctx SpecContext) {
@@ -447,7 +443,7 @@ var _ = Describe("nex node", func() {
 								It("should complete an agent handshake for each VM in the configured pool size", func(ctx SpecContext) {
 									workloads, _ := nodeProxy.WorkloadManager().RunningWorkloads()
 									for _, workload := range workloads {
-										subsz, _ := nodeProxy.InternalNATS().Subsz(&server.SubszOptions{
+										subsz, _ := managerProxy.InternalNATS().Subsz(&server.SubszOptions{
 											Subscriptions: true,
 											Test:          fmt.Sprintf("agentint.%s.handshake", workload.Id),
 										})

--- a/spec/node_windows_test.go
+++ b/spec/node_windows_test.go
@@ -267,14 +267,6 @@ var _ = Describe("nex node", func() {
 						Expect(nodeProxy.NodeConfiguration()).ToNot(BeNil()) // FIXME-- assert that it is === to the current nex node config JSON
 					})
 
-					It("should initialize an internal NATS server for private communication between running VMs and the host", func(ctx SpecContext) {
-						Expect(nodeProxy.InternalNATS()).ToNot(BeNil())
-					})
-
-					It("should initialize a connection to the internal NATS server", func(ctx SpecContext) {
-						Expect(nodeProxy.InternalNATSConn()).ToNot(BeNil())
-					})
-
 					It("should initialize a machine manager to manage firecracker VMs and communicate with running agents", func(ctx SpecContext) {
 						Expect(nodeProxy.WorkloadManager()).ToNot(BeNil())
 					})
@@ -361,8 +353,12 @@ var _ = Describe("nex node", func() {
 							Expect(managerProxy.NodeConfiguration()).To(Equal(nodeProxy.NodeConfiguration())) // FIXME-- assert that it is === to the current nex node config JSON
 						})
 
-						It("should receive a reference to the internal NATS server connection", func(ctx SpecContext) {
-							Expect(managerProxy.InternalNATSConn()).To(Equal(nodeProxy.InternalNATSConn()))
+						It("should initialize an internal NATS server for private communication between running VMs and the host", func(ctx SpecContext) {
+							Expect(managerProxy.InternalNATS()).ToNot(BeNil())
+						})
+
+						It("should initialize a connection to the internal NATS server", func(ctx SpecContext) {
+							Expect(managerProxy.InternalNATSConn()).ToNot(BeNil())
 						})
 
 						It("should receive a reference to the telemetry instance", func(ctx SpecContext) {
@@ -374,7 +370,7 @@ var _ = Describe("nex node", func() {
 								It("should complete an agent handshake for each VM in the configured pool size", func(ctx SpecContext) {
 									workloads, _ := nodeProxy.WorkloadManager().RunningWorkloads()
 									for _, workload := range workloads {
-										subsz, _ := nodeProxy.InternalNATS().Subsz(&server.SubszOptions{
+										subsz, _ := managerProxy.InternalNATS().Subsz(&server.SubszOptions{
 											Subscriptions: true,
 											Test:          fmt.Sprintf("agentint.%s.handshake", workload.Id),
 										})


### PR DESCRIPTION
This set of changes will make the internal NATS server multi-tenant safe by provisioning a user/account for each workload, and keeping the workload binary cache in a separate object store (one in each user account). 