### PR TITLE
adds the ability to bootstrap workloads at node start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ nex/nex
 rootfs.ext4
 
 test/panicker/panicker
+pnats
 .idea
 
 _spec

--- a/control-api/run.go
+++ b/control-api/run.go
@@ -203,9 +203,9 @@ func TriggerSubjects(triggerSubjects []string) RequestOption {
 }
 
 // Location of the workload. For files in NATS object stores, use nats://BUCKET/key
-func Location(fileUrl string) RequestOption {
+func Location(workloadUrl string) RequestOption {
 	return func(o requestOptions) requestOptions {
-		nurl, err := url.Parse(fileUrl)
+		nurl, err := url.Parse(workloadUrl)
 		if err != nil {
 			o.location = url.URL{}
 		} else {

--- a/examples/nodeconfigs/autostart_config.json
+++ b/examples/nodeconfigs/autostart_config.json
@@ -1,0 +1,33 @@
+{
+    "default_resource_dir": "/tmp/wd",
+    "machine_pool_size": 1,
+    "cni": {
+        "network_name": "fcnet",
+        "interface_name": "veth0"
+    },
+    "machine_template": {
+        "vcpu_count": 1,
+        "memsize_mib": 256
+    },
+    "tags": {
+        "bootstrapper": "true"
+    },
+    "no_sandbox": true,
+    "autostart": {
+        "workloads": [
+            {
+                "name": "echofunctionjs",
+                "namespace": "default",
+                "description": "automatically started function",
+                "type": "v8",
+                "location": "nats://NEXCLIFILES/echofunctionjs",
+                "issuer_seed": "SAAIKXVKF7FXKVIMW4S6ILMZHH3422OI2GYAK33N6N6LLKUBU5EKMI5QKU",
+                "xkey_seed": "SXAOXATV432FNJOO7IR4D2GQI4CXVIFIVAUKVC7I5D5ANRAMLNSWD4JXTY",
+                "trigger_subjects": [
+                    "hello.function"
+                ]    
+            }
+
+        ]
+    }
+}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -59,6 +59,7 @@ type NodeConfiguration struct {
 	ValidIssuers                     []string            `json:"valid_issuers,omitempty"`
 	WorkloadTypes                    []NexWorkload       `json:"workload_types,omitempty"`
 	HostServicesConfiguration        *HostServicesConfig `json:"host_services,omitempty"`
+	AutostartConfiguration           *AutostartConfig    `json:"autostart,omitempty"`
 
 	// Public NATS server options; when non-nil, a public "userland" NATS server is started during node init
 	PublicNATSServer *server.Options `json:"public_nats_server,omitempty"`
@@ -76,6 +77,24 @@ type HostServicesConfig struct {
 type ServiceConfig struct {
 	Enabled       bool            `json:"enabled"`
 	Configuration json.RawMessage `json:"config"`
+}
+
+type AutostartConfig struct {
+	Workloads []AutostartDeployRequest `json:"workloads"`
+}
+
+type AutostartDeployRequest struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	Argv              []string          `json:"argv,omitempty"`
+	Description       *string           `json:"description,omitempty"`
+	WorkloadType      NexWorkload       `json:"type"`
+	Location          string            `json:"location"`
+	IssuerSeed        string            `json:"issuer_seed"`
+	PublisherXKeySeed string            `json:"xkey_seed"`
+	JsDomain          *string           `json:"jsdomain,omitempty"`
+	Environment       map[string]string `json:"environment"`
+	TriggerSubjects   []string          `json:"trigger_subjects,omitempty"`
 }
 
 func (c *NodeConfiguration) Validate() bool {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -458,6 +458,12 @@ func (n *Node) handleAutostarts() {
 			controlapi.TriggerSubjects(autostart.TriggerSubjects),
 			controlapi.WorkloadDescription(*autostart.Description),
 		)
+		if err != nil {
+			n.log.Error("Failed to create deployment request for autostart workload",
+				slog.Any("error", err),
+			)
+			continue
+		}
 		_, err = request.Validate()
 		if err != nil {
 			n.log.Error("Failed to validate autostart deployment request",

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
 	controlapi "github.com/synadia-io/nex/control-api"
+	agentapi "github.com/synadia-io/nex/internal/agent-api"
 	"github.com/synadia-io/nex/internal/models"
 	"github.com/synadia-io/nex/internal/node/observability"
 )
@@ -304,6 +305,10 @@ func (n *Node) init() error {
 			}
 		}
 
+		if n.config.AutostartConfiguration != nil {
+			go n.handleAutostarts()
+		}
+
 		n.installSignalHandlers()
 	})
 
@@ -417,6 +422,97 @@ func (n *Node) startPublicNATS() error {
 	}
 
 	return nil
+}
+
+func (n *Node) handleAutostarts() {
+	time.Sleep(2 * time.Second) // delay a bit before attempting autostarts
+
+	for _, autostart := range n.config.AutostartConfiguration.Workloads {
+		issuerKp, err := nkeys.FromSeed([]byte(autostart.IssuerSeed))
+		if err != nil {
+			n.log.Error("Failed to create issuer from autostart request seed",
+				slog.Any("error", err),
+				slog.String("seed", autostart.IssuerSeed),
+			)
+			continue
+		}
+		xkey, err := nkeys.FromCurveSeed([]byte(autostart.PublisherXKeySeed))
+		if err != nil {
+			n.log.Error("Failed to load publisher xkey seed",
+				slog.Any("error", err),
+				slog.String("seed", autostart.PublisherXKeySeed),
+			)
+			continue
+		}
+		request, err := controlapi.NewDeployRequest(
+			controlapi.Argv(autostart.Argv),
+			controlapi.Location(autostart.Location),
+			controlapi.Environment(autostart.Environment),
+			controlapi.Essential(false), // avoid startup flapping, also not supported for funcs
+			controlapi.Issuer(issuerKp),
+			controlapi.SenderXKey(xkey),
+			controlapi.TargetNode(n.publicKey),
+			controlapi.TargetPublicXKey(n.api.PublicXKey()),
+			controlapi.WorkloadName(autostart.Name),
+			controlapi.WorkloadType(autostart.WorkloadType),
+			controlapi.TriggerSubjects(autostart.TriggerSubjects),
+			controlapi.WorkloadDescription(*autostart.Description),
+		)
+		_, err = request.Validate()
+		if err != nil {
+			n.log.Error("Failed to validate autostart deployment request",
+				slog.Any("error", err),
+			)
+			continue
+		}
+		agentDeployRequest := &agentapi.DeployRequest{
+			Argv:                 request.Argv,
+			DecodedClaims:        request.DecodedClaims,
+			Description:          request.Description,
+			EncryptedEnvironment: request.Environment,
+			Environment:          request.WorkloadEnvironment,
+			Essential:            request.Essential,
+			JsDomain:             request.JsDomain,
+			Location:             request.Location,
+			Namespace:            &autostart.Namespace,
+			RetryCount:           request.RetryCount,
+			RetriedAt:            request.RetriedAt,
+			SenderPublicKey:      request.SenderPublicKey,
+			TargetNode:           request.TargetNode,
+			TriggerSubjects:      request.TriggerSubjects,
+			WorkloadName:         &request.DecodedClaims.Subject,
+			WorkloadType:         request.WorkloadType,
+			WorkloadJwt:          request.WorkloadJwt,
+		}
+
+		numBytes, workloadHash, err := n.api.mgr.CacheWorkload(request)
+		if err != nil {
+			n.api.log.Error("Failed to cache auto-start workload bytes",
+				slog.Any("err", err),
+				slog.String("name", autostart.Name),
+				slog.String("namespace", autostart.Namespace),
+				slog.String("url", autostart.Location),
+			)
+			continue
+		}
+		agentDeployRequest.TotalBytes = int64(numBytes)
+		agentDeployRequest.Hash = *workloadHash
+
+		workloadId, err := n.api.mgr.DeployWorkload(agentDeployRequest)
+		if err != nil {
+			n.log.Error("Failed to deploy autostart workload",
+				slog.Any("error", err),
+				slog.String("name", autostart.Name),
+				slog.String("namespace", autostart.Namespace),
+			)
+			continue
+		}
+		n.log.Info("Autostart workload started",
+			slog.String("name", autostart.Name),
+			slog.String("namespace", autostart.Namespace),
+			slog.String("workload_id", *workloadId),
+		)
+	}
 }
 
 func (n *Node) loadNodeConfig() error {


### PR DESCRIPTION
See the sample config in `nodeconfigs` for how this is set up. It's basically the key parameters from a run request, just applied automatically at startup.

Note that because of the anti-tamper protection, only a nex client using the same seeds from the node config will be able to terminate that workload (this is a good thing :tm: )