### PR TITLE
moves nexworkload string newtype to controlapi

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
 	"github.com/synadia-io/nex/agent/providers"
+	controlapi "github.com/synadia-io/nex/control-api"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
 	"github.com/synadia-io/nex/internal/models"
 	"go.opentelemetry.io/otel"
@@ -171,7 +172,7 @@ func (a *Agent) cacheExecutableArtifact(req *agentapi.DeployRequest) (*string, e
 	fileName := fmt.Sprintf("workload-%s", *a.md.VmID)
 	tempFile := path.Join(os.TempDir(), fileName)
 
-	if strings.EqualFold(runtime.GOOS, "windows") && req.WorkloadType == models.NexWorkloadNative {
+	if strings.EqualFold(runtime.GOOS, "windows") && req.WorkloadType == controlapi.NexWorkloadNative {
 		tempFile = fmt.Sprintf("%s.exe", tempFile)
 	}
 
@@ -274,7 +275,7 @@ func (a *Agent) handleDeploy(m *nats.Msg) {
 	a.provider = provider
 
 	shouldValidate := true
-	if !a.sandboxed && request.WorkloadType == models.NexWorkloadNative {
+	if !a.sandboxed && request.WorkloadType == controlapi.NexWorkloadNative {
 		shouldValidate = false
 	}
 

--- a/agent/providers/api.go
+++ b/agent/providers/api.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 
 	"github.com/synadia-io/nex/agent/providers/lib"
+	controlapi "github.com/synadia-io/nex/control-api"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
-	"github.com/synadia-io/nex/internal/models"
 )
 
 // ExecutionProvider implementations provide support for a specific
@@ -34,14 +34,14 @@ func NewExecutionProvider(params *agentapi.ExecutionProviderParams) (ExecutionPr
 	// }
 
 	switch params.WorkloadType {
-	case models.NexWorkloadNative:
+	case controlapi.NexWorkloadNative:
 		return lib.InitNexExecutionProviderNative(params)
-	case models.NexWorkloadV8:
+	case controlapi.NexWorkloadV8:
 		return lib.InitNexExecutionProviderV8(params)
-	case models.NexWorkloadOCI:
+	case controlapi.NexWorkloadOCI:
 		// TODO-- return lib.InitNexExecutionProviderOCI(params), nil
 		return nil, errors.New("oci execution provider not yet implemented")
-	case models.NexWorkloadWasm:
+	case controlapi.NexWorkloadWasm:
 		return lib.InitNexExecutionProviderWasm(params)
 	default:
 		break

--- a/control-api/run.go
+++ b/control-api/run.go
@@ -11,15 +11,14 @@ import (
 
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
-	"github.com/synadia-io/nex/internal/models"
 )
 
 type DeployRequest struct {
-	Argv         []string           `json:"argv,omitempty"`
-	Description  *string            `json:"description,omitempty"`
-	WorkloadType models.NexWorkload `json:"type"`
-	Location     *url.URL           `json:"location"`
-	Essential    *bool              `json:"essential,omitempty"`
+	Argv         []string    `json:"argv,omitempty"`
+	Description  *string     `json:"description,omitempty"`
+	WorkloadType NexWorkload `json:"type"`
+	Location     *url.URL    `json:"location"`
+	Essential    *bool       `json:"essential,omitempty"`
 
 	// Contains claims for the workload: name, hash
 	WorkloadJwt *string `json:"workload_jwt"`
@@ -146,7 +145,7 @@ func (request *DeployRequest) DecryptRequestEnvironment(recipientXKey nkeys.KeyP
 type requestOptions struct {
 	argv                []string
 	workloadName        string
-	workloadType        models.NexWorkload
+	workloadType        NexWorkload
 	workloadDescription string
 	location            url.URL
 	env                 map[string]string
@@ -179,7 +178,7 @@ func WorkloadName(name string) RequestOption {
 }
 
 // Type of the workload, e.g., one of "native", "v8", "oci", "wasm" for this request
-func WorkloadType(workloadType models.NexWorkload) RequestOption {
+func WorkloadType(workloadType NexWorkload) RequestOption {
 	return func(o requestOptions) requestOptions {
 		o.workloadType = workloadType
 		return o

--- a/control-api/types.go
+++ b/control-api/types.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 
 	cloudevents "github.com/cloudevents/sdk-go"
-	"github.com/synadia-io/nex/internal/models"
 )
 
 const (
@@ -33,12 +32,27 @@ type RunResponse struct {
 	Name    string `json:"name"`
 }
 
+type NexWorkload string
+
+const (
+	NexWorkloadNative NexWorkload = "native"
+	NexWorkloadV8     NexWorkload = "v8"
+	NexWorkloadOCI    NexWorkload = "oci"
+	NexWorkloadWasm   NexWorkload = "wasm"
+)
+
+type NodeCapabilities struct {
+	Sandboxable        bool              `json:"sandboxable"`
+	SupportedProviders []NexWorkload     `json:"supported_providers"`
+	NodeTags           map[string]string `json:"node_tags"`
+}
+
 type AuctionRequest struct {
-	Arch          *string              `json:"arch,omitempty"`
-	OS            *string              `json:"os,omitempty"`
-	Sandboxed     *bool                `json:"sandboxed,omitempty"`
-	Tags          map[string]string    `json:"tags,omitempty"`
-	WorkloadTypes []models.NexWorkload `json:"workload_types,omitempty"`
+	Arch          *string           `json:"arch,omitempty"`
+	OS            *string           `json:"os,omitempty"`
+	Sandboxed     *bool             `json:"sandboxed,omitempty"`
+	Tags          map[string]string `json:"tags,omitempty"`
+	WorkloadTypes []NexWorkload     `json:"workload_types,omitempty"`
 }
 
 type AuctionResponse PingResponse
@@ -64,10 +78,10 @@ type WorkloadPingResponse struct {
 }
 
 type WorkloadPingMachineSummary struct {
-	Id           string             `json:"id"`
-	Namespace    string             `json:"namespace"`
-	Name         string             `json:"name"`
-	WorkloadType models.NexWorkload `json:"type"`
+	Id           string      `json:"id"`
+	Namespace    string      `json:"namespace"`
+	Name         string      `json:"name"`
+	WorkloadType NexWorkload `json:"type"`
 }
 
 type LameDuckResponse struct {
@@ -82,13 +96,13 @@ type MemoryStat struct {
 }
 
 type InfoResponse struct {
-	Version                string               `json:"version"`
-	Uptime                 string               `json:"uptime"`
-	PublicXKey             string               `json:"public_xkey"`
-	Tags                   map[string]string    `json:"tags,omitempty"`
-	Memory                 *MemoryStat          `json:"memory,omitempty"`
-	Machines               []MachineSummary     `json:"machines"`
-	SupportedWorkloadTypes []models.NexWorkload `json:"supported_workload_types,omitempty"`
+	Version                string            `json:"version"`
+	Uptime                 string            `json:"uptime"`
+	PublicXKey             string            `json:"public_xkey"`
+	Tags                   map[string]string `json:"tags,omitempty"`
+	Memory                 *MemoryStat       `json:"memory,omitempty"`
+	Machines               []MachineSummary  `json:"machines"`
+	SupportedWorkloadTypes []NexWorkload     `json:"supported_workload_types,omitempty"`
 }
 
 type MachineSummary struct {
@@ -100,11 +114,11 @@ type MachineSummary struct {
 }
 
 type WorkloadSummary struct {
-	Name         string             `json:"name"`
-	Description  string             `json:"description,omitempty"`
-	Runtime      string             `json:"runtime"`
-	WorkloadType models.NexWorkload `json:"type"`
-	Hash         string             `json:"hash"`
+	Name         string      `json:"name"`
+	Description  string      `json:"description,omitempty"`
+	Runtime      string      `json:"runtime"`
+	WorkloadType NexWorkload `json:"type"`
+	Hash         string      `json:"hash"`
 }
 
 type Envelope struct {

--- a/internal/agent-api/types.go
+++ b/internal/agent-api/types.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
-	"github.com/synadia-io/nex/internal/models"
+	controlapi "github.com/synadia-io/nex/control-api"
 )
 
 // Name of the internal, non-public bucket for sharing files between host and agent
@@ -44,19 +44,19 @@ type ExecutionProviderParams struct {
 
 // DeployRequest processed by the agent
 type DeployRequest struct {
-	Argv            []string           `json:"argv,omitempty"`
-	DecodedClaims   jwt.GenericClaims  `json:"-"`
-	Description     *string            `json:"description"`
-	Environment     map[string]string  `json:"environment"`
-	Essential       *bool              `json:"essential,omitempty"`
-	Hash            string             `json:"hash,omitempty"`
-	Namespace       *string            `json:"namespace,omitempty"`
-	RetriedAt       *time.Time         `json:"retried_at,omitempty"`
-	RetryCount      *uint              `json:"retry_count,omitempty"`
-	TotalBytes      int64              `json:"total_bytes,omitempty"`
-	TriggerSubjects []string           `json:"trigger_subjects"`
-	WorkloadName    *string            `json:"workload_name,omitempty"`
-	WorkloadType    models.NexWorkload `json:"workload_type,omitempty"`
+	Argv            []string               `json:"argv,omitempty"`
+	DecodedClaims   jwt.GenericClaims      `json:"-"`
+	Description     *string                `json:"description"`
+	Environment     map[string]string      `json:"environment"`
+	Essential       *bool                  `json:"essential,omitempty"`
+	Hash            string                 `json:"hash,omitempty"`
+	Namespace       *string                `json:"namespace,omitempty"`
+	RetriedAt       *time.Time             `json:"retried_at,omitempty"`
+	RetryCount      *uint                  `json:"retry_count,omitempty"`
+	TotalBytes      int64                  `json:"total_bytes,omitempty"`
+	TriggerSubjects []string               `json:"trigger_subjects"`
+	WorkloadName    *string                `json:"workload_name,omitempty"`
+	WorkloadType    controlapi.NexWorkload `json:"workload_type,omitempty"`
 
 	Stderr      io.Writer `json:"-"`
 	Stdout      io.Writer `json:"-"`
@@ -78,14 +78,14 @@ func (request *DeployRequest) IsEssential() bool {
 
 // Returns true if the run request supports essential flag
 func (request *DeployRequest) SupportsEssential() bool {
-	return request.WorkloadType == models.NexWorkloadNative ||
-		request.WorkloadType == models.NexWorkloadOCI
+	return request.WorkloadType == controlapi.NexWorkloadNative ||
+		request.WorkloadType == controlapi.NexWorkloadOCI
 }
 
 // Returns true if the run request supports trigger subjects
 func (request *DeployRequest) SupportsTriggerSubjects() bool {
-	return (request.WorkloadType == models.NexWorkloadV8 ||
-		request.WorkloadType == models.NexWorkloadWasm) &&
+	return (request.WorkloadType == controlapi.NexWorkloadV8 ||
+		request.WorkloadType == controlapi.NexWorkloadWasm) &&
 		len(request.TriggerSubjects) > 0
 }
 
@@ -114,8 +114,8 @@ func (r *DeployRequest) Validate() error {
 
 	if r.WorkloadType == "" {
 		err = errors.Join(err, errors.New("workload type is required"))
-	} else if (r.WorkloadType == models.NexWorkloadV8 ||
-		r.WorkloadType == models.NexWorkloadWasm) &&
+	} else if (r.WorkloadType == controlapi.NexWorkloadV8 ||
+		r.WorkloadType == controlapi.NexWorkloadWasm) &&
 		len(r.TriggerSubjects) == 0 {
 		err = errors.Join(err, errors.New("at least one trigger subject is required for this workload type"))
 	}

--- a/internal/models/cli.go
+++ b/internal/models/cli.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats.go"
+	controlapi "github.com/synadia-io/nex/control-api"
 )
 
 type UiOptions struct {
@@ -72,7 +73,7 @@ type RunOptions struct {
 	TargetNode        string
 	WorkloadUrl       *url.URL
 	Name              string
-	WorkloadType      NexWorkload
+	WorkloadType      controlapi.NexWorkload
 	Description       string
 	PublisherXkeyFile string
 	ClaimsIssuerFile  string

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/splode/fname"
+	controlapi "github.com/synadia-io/nex/control-api"
 )
 
 const (
@@ -25,7 +26,7 @@ const (
 )
 
 var (
-	DefaultWorkloadTypes = []NexWorkload{NexWorkloadNative}
+	DefaultWorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative}
 
 	DefaultBinPath = append([]string{"/usr/local/bin"}, filepath.SplitList(os.Getenv("PATH"))...)
 
@@ -36,32 +37,32 @@ var (
 // Node configuration is used to configure the node process as well
 // as the virtual machines it produces
 type NodeConfiguration struct {
-	AgentHandshakeTimeoutMillisecond int                 `json:"agent_handshake_timeout_ms,omitempty"`
-	AgentPingTimeoutMillisecond      int                 `json:"agent_ping_timeout_ms,omitempty"`
-	BinPath                          []string            `json:"bin_path"`
-	CNI                              CNIDefinition       `json:"cni"`
-	DefaultResourceDir               string              `json:"default_resource_dir"`
-	ForceDepInstall                  bool                `json:"-"`
-	InternalNodeHost                 *string             `json:"internal_node_host,omitempty"`
-	InternalNodePort                 *int                `json:"internal_node_port"`
-	KernelFilepath                   string              `json:"kernel_filepath"`
-	MachinePoolSize                  int                 `json:"machine_pool_size"`
-	MachineTemplate                  MachineTemplate     `json:"machine_template"`
-	NoSandbox                        bool                `json:"no_sandbox,omitempty"`
-	OtlpExporterUrl                  string              `json:"otlp_exporter_url,omitempty"`
-	OtelMetrics                      bool                `json:"otel_metrics"`
-	OtelMetricsPort                  int                 `json:"otel_metrics_port"`
-	OtelMetricsExporter              string              `json:"otel_metrics_exporter"`
-	OtelTraces                       bool                `json:"otel_traces"`
-	OtelTracesExporter               string              `json:"otel_traces_exporter"`
-	PreserveNetwork                  bool                `json:"preserve_network,omitempty"`
-	RateLimiters                     *Limiters           `json:"rate_limiters,omitempty"`
-	RootFsFilepath                   string              `json:"rootfs_filepath"`
-	Tags                             map[string]string   `json:"tags,omitempty"`
-	ValidIssuers                     []string            `json:"valid_issuers,omitempty"`
-	WorkloadTypes                    []NexWorkload       `json:"workload_types,omitempty"`
-	HostServicesConfiguration        *HostServicesConfig `json:"host_services,omitempty"`
-	AutostartConfiguration           *AutostartConfig    `json:"autostart,omitempty"`
+	AgentHandshakeTimeoutMillisecond int                      `json:"agent_handshake_timeout_ms,omitempty"`
+	AgentPingTimeoutMillisecond      int                      `json:"agent_ping_timeout_ms,omitempty"`
+	BinPath                          []string                 `json:"bin_path"`
+	CNI                              CNIDefinition            `json:"cni"`
+	DefaultResourceDir               string                   `json:"default_resource_dir"`
+	ForceDepInstall                  bool                     `json:"-"`
+	InternalNodeHost                 *string                  `json:"internal_node_host,omitempty"`
+	InternalNodePort                 *int                     `json:"internal_node_port"`
+	KernelFilepath                   string                   `json:"kernel_filepath"`
+	MachinePoolSize                  int                      `json:"machine_pool_size"`
+	MachineTemplate                  MachineTemplate          `json:"machine_template"`
+	NoSandbox                        bool                     `json:"no_sandbox,omitempty"`
+	OtlpExporterUrl                  string                   `json:"otlp_exporter_url,omitempty"`
+	OtelMetrics                      bool                     `json:"otel_metrics"`
+	OtelMetricsPort                  int                      `json:"otel_metrics_port"`
+	OtelMetricsExporter              string                   `json:"otel_metrics_exporter"`
+	OtelTraces                       bool                     `json:"otel_traces"`
+	OtelTracesExporter               string                   `json:"otel_traces_exporter"`
+	PreserveNetwork                  bool                     `json:"preserve_network,omitempty"`
+	RateLimiters                     *Limiters                `json:"rate_limiters,omitempty"`
+	RootFsFilepath                   string                   `json:"rootfs_filepath"`
+	Tags                             map[string]string        `json:"tags,omitempty"`
+	ValidIssuers                     []string                 `json:"valid_issuers,omitempty"`
+	WorkloadTypes                    []controlapi.NexWorkload `json:"workload_types,omitempty"`
+	HostServicesConfiguration        *HostServicesConfig      `json:"host_services,omitempty"`
+	AutostartConfiguration           *AutostartConfig         `json:"autostart,omitempty"`
 
 	// Public NATS server options; when non-nil, a public "userland" NATS server is started during node init
 	PublicNATSServer *server.Options `json:"public_nats_server,omitempty"`
@@ -86,15 +87,15 @@ type AutostartConfig struct {
 }
 
 type AutostartDeployRequest struct {
-	Name            string            `json:"name"`
-	Namespace       string            `json:"namespace"`
-	Argv            []string          `json:"argv,omitempty"`
-	Description     *string           `json:"description,omitempty"`
-	WorkloadType    NexWorkload       `json:"type"`
-	Location        string            `json:"location"`
-	JsDomain        *string           `json:"jsdomain,omitempty"`
-	Environment     map[string]string `json:"environment"`
-	TriggerSubjects []string          `json:"trigger_subjects,omitempty"`
+	Name            string                 `json:"name"`
+	Namespace       string                 `json:"namespace"`
+	Argv            []string               `json:"argv,omitempty"`
+	Description     *string                `json:"description,omitempty"`
+	WorkloadType    controlapi.NexWorkload `json:"type"`
+	Location        string                 `json:"location"`
+	JsDomain        *string                `json:"jsdomain,omitempty"`
+	Environment     map[string]string      `json:"environment"`
+	TriggerSubjects []string               `json:"trigger_subjects,omitempty"`
 }
 
 func (c *NodeConfiguration) Validate() bool {

--- a/internal/models/node_capabilities.go
+++ b/internal/models/node_capabilities.go
@@ -1,16 +1,1 @@
 package models
-
-type NexWorkload string
-
-const (
-	NexWorkloadNative NexWorkload = "native"
-	NexWorkloadV8     NexWorkload = "v8"
-	NexWorkloadOCI    NexWorkload = "oci"
-	NexWorkloadWasm   NexWorkload = "wasm"
-)
-
-type NodeCapabilities struct {
-	Sandboxable        bool              `json:"sandboxable"`
-	SupportedProviders []NexWorkload     `json:"supported_providers"`
-	NodeTags           map[string]string `json:"node_tags"`
-}

--- a/internal/models/node_darwin.go
+++ b/internal/models/node_darwin.go
@@ -1,12 +1,14 @@
 package models
 
-func GetNodeCapabilities(tags map[string]string) *NodeCapabilities {
-	return &NodeCapabilities{
+import controlapi "github.com/synadia-io/nex/control-api"
+
+func GetNodeCapabilities(tags map[string]string) *controlapi.NodeCapabilities {
+	return &controlapi.NodeCapabilities{
 		Sandboxable: false,
-		SupportedProviders: []NexWorkload{
-			NexWorkloadNative,
-			NexWorkloadOCI,
-			NexWorkloadWasm,
+		SupportedProviders: []controlapi.NexWorkload{
+			controlapi.NexWorkloadNative,
+			controlapi.NexWorkloadOCI,
+			controlapi.NexWorkloadWasm,
 		},
 		NodeTags: tags,
 	}

--- a/internal/models/node_linux_amd64.go
+++ b/internal/models/node_linux_amd64.go
@@ -1,13 +1,15 @@
 package models
 
-func GetNodeCapabilities(tags map[string]string) *NodeCapabilities {
-	return &NodeCapabilities{
+import controlapi "github.com/synadia-io/nex/control-api"
+
+func GetNodeCapabilities(tags map[string]string) *controlapi.NodeCapabilities {
+	return &controlapi.NodeCapabilities{
 		Sandboxable: true,
-		SupportedProviders: []NexWorkload{
-			NexWorkloadNative,
-			NexWorkloadOCI,
-			NexWorkloadWasm,
-			NexWorkloadV8,
+		SupportedProviders: []controlapi.NexWorkload{
+			controlapi.NexWorkloadNative,
+			controlapi.NexWorkloadOCI,
+			controlapi.NexWorkloadWasm,
+			controlapi.NexWorkloadV8,
 		},
 		NodeTags: tags,
 	}

--- a/internal/models/node_linux_arm64.go
+++ b/internal/models/node_linux_arm64.go
@@ -1,12 +1,14 @@
 package models
 
-func GetNodeCapabilities(tags map[string]string) *NodeCapabilities {
-	return &NodeCapabilities{
+import controlapi "github.com/synadia-io/nex/control-api"
+
+func GetNodeCapabilities(tags map[string]string) *controlapi.NodeCapabilities {
+	return &controlapi.NodeCapabilities{
 		Sandboxable: true,
-		SupportedProviders: []NexWorkload{
-			NexWorkloadNative,
-			NexWorkloadOCI,
-			NexWorkloadWasm,
+		SupportedProviders: []controlapi.NexWorkload{
+			controlapi.NexWorkloadNative,
+			controlapi.NexWorkloadOCI,
+			controlapi.NexWorkloadWasm,
 		},
 		NodeTags: tags,
 	}

--- a/internal/models/node_windows.go
+++ b/internal/models/node_windows.go
@@ -1,10 +1,12 @@
 package models
 
-func GetNodeCapabilities(tags map[string]string) *NodeCapabilities {
-	return &NodeCapabilities{
+import controlapi "github.com/synadia-io/nex/control-api"
+
+func GetNodeCapabilities(tags map[string]string) *controlapi.NodeCapabilities {
+	return &controlapi.NodeCapabilities{
 		Sandboxable: false,
-		SupportedProviders: []NexWorkload{
-			NexWorkloadNative,
+		SupportedProviders: []controlapi.NexWorkload{
+			controlapi.NexWorkloadNative,
 		},
 		NodeTags: tags,
 	}

--- a/internal/node/config.go
+++ b/internal/node/config.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	controlapi "github.com/synadia-io/nex/control-api"
 	"github.com/synadia-io/nex/internal/models"
 )
 
@@ -25,7 +26,7 @@ func LoadNodeConfiguration(configFilepath string) (*models.NodeConfiguration, er
 	}
 
 	if len(config.WorkloadTypes) == 0 {
-		config.WorkloadTypes = []models.NexWorkload{models.NexWorkloadNative}
+		config.WorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative}
 	}
 
 	if strings.EqualFold(runtime.GOOS, "windows") && !config.NoSandbox {

--- a/internal/node/controlapi.go
+++ b/internal/node/controlapi.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	controlapi "github.com/synadia-io/nex/control-api"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
-	"github.com/synadia-io/nex/internal/models"
 )
 
 // The API listener is the command and control interface for the node server
@@ -245,8 +244,8 @@ func (api *ApiListener) handleDeploy(m *nats.Msg) {
 		return
 	}
 
-	if len(request.TriggerSubjects) > 0 && (request.WorkloadType != models.NexWorkloadV8 &&
-		request.WorkloadType != models.NexWorkloadWasm) { // FIXME -- workload type comparison
+	if len(request.TriggerSubjects) > 0 && (request.WorkloadType != controlapi.NexWorkloadV8 &&
+		request.WorkloadType != controlapi.NexWorkloadWasm) { // FIXME -- workload type comparison
 		api.log.Error("Workload type does not support trigger subject registration", slog.String("trigger_subjects", string(request.WorkloadType)))
 		respondFail(controlapi.RunResponseType, m, fmt.Sprintf("Unsupported workload type for trigger subject registration: %s", string(request.WorkloadType)))
 		return

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -66,7 +66,7 @@ type Node struct {
 	startedAt time.Time
 	telemetry *observability.Telemetry
 
-	capabilities models.NodeCapabilities
+	capabilities controlapi.NodeCapabilities
 }
 
 func NewNode(

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -299,7 +299,7 @@ func (w *WorkloadManager) RunningWorkloads() ([]controlapi.MachineSummary, error
 		agentClient, ok := w.activeAgents[p.ID]
 		if ok {
 			uptimeFriendly = myUptime(agentClient.UptimeMillis())
-			if p.DeployRequest.WorkloadType == models.NexWorkloadV8 || p.DeployRequest.WorkloadType == models.NexWorkloadWasm {
+			if p.DeployRequest.WorkloadType == controlapi.NexWorkloadV8 || p.DeployRequest.WorkloadType == controlapi.NexWorkloadWasm {
 				nanoTime := fmt.Sprintf("%dns", agentClient.ExecTimeNanos())
 				rt, err := time.ParseDuration(nanoTime)
 				if err == nil {

--- a/nex/devrunner.go
+++ b/nex/devrunner.go
@@ -25,7 +25,7 @@ var (
 
 const (
 	defaultFileMode     = os.FileMode(int(0770)) // owner and group r/w/x
-	defaultWorkloadType = models.NexWorkloadNative
+	defaultWorkloadType = controlapi.NexWorkloadNative
 	fileExtensionJS     = "js"
 	fileExtensionWasm   = "wasm"
 
@@ -149,7 +149,7 @@ func RunDevWorkload(ctx context.Context, logger *slog.Logger) error {
 	return nil
 }
 
-func randomNode(nodeClient *controlapi.Client, arch, os string, workloadType models.NexWorkload) (*controlapi.AuctionResponse, error) {
+func randomNode(nodeClient *controlapi.Client, arch, os string, workloadType controlapi.NexWorkload) (*controlapi.AuctionResponse, error) {
 	candidates, err := auction(nodeClient, os, arch, workloadType)
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func randomNode(nodeClient *controlapi.Client, arch, os string, workloadType mod
 	return &candidates[rand.Intn(len(candidates))], nil
 }
 
-func auction(nodeClient *controlapi.Client, os, arch string, workloadType models.NexWorkload) ([]controlapi.AuctionResponse, error) {
+func auction(nodeClient *controlapi.Client, os, arch string, workloadType controlapi.NexWorkload) ([]controlapi.AuctionResponse, error) {
 	var _os, _arch *string
 	if os != "" {
 		_os = &os
@@ -170,7 +170,7 @@ func auction(nodeClient *controlapi.Client, os, arch string, workloadType models
 	candidates, err := nodeClient.Auction(&controlapi.AuctionRequest{
 		Arch:          _arch,
 		OS:            _os,
-		WorkloadTypes: []models.NexWorkload{workloadType},
+		WorkloadTypes: []controlapi.NexWorkload{workloadType},
 	})
 	if err != nil {
 		return nil, err

--- a/nex/nex.go
+++ b/nex/nex.go
@@ -15,6 +15,7 @@ import (
 	shandler "github.com/jordan-rash/slog-handler"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
+	controlapi "github.com/synadia-io/nex/control-api"
 	"github.com/synadia-io/nex/internal/models"
 	natslogger "github.com/synadia-io/nex/internal/nats-logger"
 	nextui "github.com/synadia-io/nex/nex/tui"
@@ -149,13 +150,13 @@ func main() {
 
 	switch workloadType {
 	case "native":
-		RunOpts.WorkloadType = models.NexWorkloadNative
+		RunOpts.WorkloadType = controlapi.NexWorkloadNative
 	case "v8":
-		RunOpts.WorkloadType = models.NexWorkloadV8
+		RunOpts.WorkloadType = controlapi.NexWorkloadV8
 	case "oci":
-		RunOpts.WorkloadType = models.NexWorkloadOCI
+		RunOpts.WorkloadType = controlapi.NexWorkloadOCI
 	case "wasm":
-		RunOpts.WorkloadType = models.NexWorkloadWasm
+		RunOpts.WorkloadType = controlapi.NexWorkloadWasm
 	}
 
 	ctx := context.Background()

--- a/spec/node_linux_test.go
+++ b/spec/node_linux_test.go
@@ -135,7 +135,7 @@ var _ = Describe("nex node", func() {
 		Context("when the specified node configuration file exists", func() {
 			BeforeEach(func() {
 				nodeConfig = models.DefaultNodeConfiguration()
-				nodeConfig.WorkloadTypes = []models.NexWorkload{models.NexWorkloadNative, models.NexWorkloadV8, models.NexWorkloadWasm}
+				nodeConfig.WorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative, controlapi.NexWorkloadV8, controlapi.NexWorkloadWasm}
 				nodeOpts.ConfigFilepath = path.Join(os.TempDir(), fmt.Sprintf("%d-spec-nex-conf.json", _fixtures.seededRand.Int()))
 			})
 
@@ -230,7 +230,7 @@ var _ = Describe("nex node", func() {
 		Context("when the specified node configuration file exists", func() {
 			BeforeEach(func() {
 				nodeConfig = models.DefaultNodeConfiguration()
-				nodeConfig.WorkloadTypes = []models.NexWorkload{models.NexWorkloadNative, models.NexWorkloadV8, models.NexWorkloadWasm}
+				nodeConfig.WorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative, controlapi.NexWorkloadV8, controlapi.NexWorkloadWasm}
 				nodeOpts.ConfigFilepath = path.Join(os.TempDir(), fmt.Sprintf("%d-spec-nex-conf.json", _fixtures.seededRand.Int()))
 
 				nodeConfig.NoSandbox = !sandbox
@@ -934,7 +934,7 @@ var _ = Describe("nex node", func() {
 	)
 })
 
-func cacheWorkloadArtifact(nc *nats.Conn, filename string) (string, string, models.NexWorkload, error) {
+func cacheWorkloadArtifact(nc *nats.Conn, filename string) (string, string, controlapi.NexWorkload, error) {
 	js, err := nc.JetStream()
 	if err != nil {
 		panic(err)
@@ -962,14 +962,14 @@ func cacheWorkloadArtifact(nc *nats.Conn, filename string) (string, string, mode
 		return "", "", "", err
 	}
 
-	var workloadType models.NexWorkload
+	var workloadType controlapi.NexWorkload
 	switch strings.Replace(filepath.Ext(filename), ".", "", 1) {
 	case "js":
-		workloadType = models.NexWorkloadV8
+		workloadType = controlapi.NexWorkloadV8
 	case "wasm":
-		workloadType = models.NexWorkloadWasm
+		workloadType = controlapi.NexWorkloadWasm
 	default:
-		workloadType = models.NexWorkloadNative
+		workloadType = controlapi.NexWorkloadNative
 	}
 
 	return fmt.Sprintf("nats://%s/%s", "NEXCLIFILES", key), key, workloadType, nil

--- a/spec/node_windows_test.go
+++ b/spec/node_windows_test.go
@@ -87,7 +87,7 @@ var _ = Describe("nex node", func() {
 			BeforeEach(func() {
 				nodeOpts.ConfigFilepath = filepath.Join(os.TempDir(), fmt.Sprintf("%d-non-existent-nex-conf.json", _fixtures.seededRand.Int()))
 				nodeConfig.NoSandbox = true
-				nodeConfig.WorkloadTypes = []models.NexWorkload{models.NexWorkloadNative, models.NexWorkloadV8, models.NexWorkloadWasm}
+				nodeConfig.WorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative, controlapi.NexWorkloadV8, controlapi.NexWorkloadWasm}
 			})
 
 			It("should not return an error", func(ctx SpecContext) {
@@ -101,7 +101,7 @@ var _ = Describe("nex node", func() {
 				nodeConfig = models.DefaultNodeConfiguration()
 				nodeConfig.NoSandbox = true
 				nodeOpts.ConfigFilepath = path.Join(os.TempDir(), fmt.Sprintf("%d-spec-nex-conf.json", _fixtures.seededRand.Int()))
-				nodeConfig.WorkloadTypes = []models.NexWorkload{models.NexWorkloadNative, models.NexWorkloadV8, models.NexWorkloadWasm}
+				nodeConfig.WorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative, controlapi.NexWorkloadV8, controlapi.NexWorkloadWasm}
 			})
 
 			JustBeforeEach(func() {
@@ -118,7 +118,7 @@ var _ = Describe("nex node", func() {
 					Context("when the specified default_resource_dir does not exist on the host", func() {
 						BeforeEach(func() {
 							nodeConfig.DefaultResourceDir = filepath.Join(os.TempDir(), fmt.Sprintf("%d-non-existent-nex-resource-dir", _fixtures.seededRand.Int()))
-							nodeConfig.WorkloadTypes = []models.NexWorkload{models.NexWorkloadNative, models.NexWorkloadV8, models.NexWorkloadWasm}
+							nodeConfig.WorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative, controlapi.NexWorkloadV8, controlapi.NexWorkloadWasm}
 						})
 
 						It("should not return an error", func(ctx SpecContext) {
@@ -182,7 +182,7 @@ var _ = Describe("nex node", func() {
 			BeforeEach(func() {
 				nodeConfig = models.DefaultNodeConfiguration()
 				nodeOpts.ConfigFilepath = path.Join(os.TempDir(), fmt.Sprintf("%d-spec-nex-conf.json", _fixtures.seededRand.Int()))
-				nodeConfig.WorkloadTypes = []models.NexWorkload{models.NexWorkloadNative, models.NexWorkloadV8, models.NexWorkloadWasm}
+				nodeConfig.WorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative, controlapi.NexWorkloadV8, controlapi.NexWorkloadWasm}
 
 				nodeConfig.NoSandbox = !sandbox
 				nodeKey, _ = nkeys.CreateServer()
@@ -482,7 +482,7 @@ var _ = Describe("nex node", func() {
 	)
 })
 
-func cacheWorkloadArtifact(nc *nats.Conn, filename string) (string, string, models.NexWorkload, error) {
+func cacheWorkloadArtifact(nc *nats.Conn, filename string) (string, string, controlapi.NexWorkload, error) {
 	js, err := nc.JetStream()
 	if err != nil {
 		panic(err)
@@ -510,16 +510,16 @@ func cacheWorkloadArtifact(nc *nats.Conn, filename string) (string, string, mode
 		return "", "", "", err
 	}
 
-	var workloadType models.NexWorkload
+	var workloadType controlapi.NexWorkload
 	switch strings.Replace(filepath.Ext(filename), ".", "", 1) {
 	case "exe":
-		workloadType = models.NexWorkloadNative
+		workloadType = controlapi.NexWorkloadNative
 	case "js":
-		workloadType = models.NexWorkloadV8
+		workloadType = controlapi.NexWorkloadV8
 	case "wasm":
-		workloadType = models.NexWorkloadWasm
+		workloadType = controlapi.NexWorkloadWasm
 	default:
-		workloadType = models.NexWorkloadNative
+		workloadType = controlapi.NexWorkloadNative
 	}
 
 	return fmt.Sprintf("nats://%s/%s", "NEXCLIFILES", key), key, workloadType, nil

--- a/test/wasm_test.go
+++ b/test/wasm_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 
 	"github.com/synadia-io/nex/agent/providers/lib"
+	controlapi "github.com/synadia-io/nex/control-api"
 	agentapi "github.com/synadia-io/nex/internal/agent-api"
-	"github.com/synadia-io/nex/internal/models"
 )
 
 func TestWasmExecution(t *testing.T) {
 	file := "../examples/wasm/echofunction/echofunction.wasm"
-	typ := models.NexWorkloadWasm
+	typ := controlapi.NexWorkloadWasm
 	params := &agentapi.ExecutionProviderParams{
 		DeployRequest: agentapi.DeployRequest{
 			Environment:  map[string]string{},


### PR DESCRIPTION
I know that newtypes are all the rage in other languages (esp. Haskell), but this is one time where it hurt us, because we had a newtype that was internal and required by external consumers.