### PR TITLE
Per-workload host services connections

### DIFF
--- a/host-services/builtins/builtins_test.go
+++ b/host-services/builtins/builtins_test.go
@@ -43,8 +43,9 @@ func TestKvBuiltin(t *testing.T) {
 	server := hostservices.NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
+	server.SetHostServicesConnection(testWorkloadId, nc)
 
-	service, _ := NewKeyValueService(nc, slog.Default())
+	service, _ := NewKeyValueService(slog.Default())
 	err := server.AddService("kv", service, nil)
 	if err != nil {
 		t.Fatalf("Failed to add service: %s", err)
@@ -84,8 +85,9 @@ func TestMessagingBuiltin(t *testing.T) {
 	server := hostservices.NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
+	server.SetHostServicesConnection(testWorkloadId, nc)
 
-	service, _ := NewMessagingService(nc, slog.Default())
+	service, _ := NewMessagingService(slog.Default())
 	_ = server.AddService("messaging", service, nil)
 	_ = server.Start()
 
@@ -110,8 +112,9 @@ func TestObjectBuiltin(t *testing.T) {
 	server := hostservices.NewHostServicesServer(nc, slog.Default(), noop.NewTracerProvider().Tracer("nex-node"))
 	client := hostservices.NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 	bClient := NewBuiltinServicesClient(client)
+	server.SetHostServicesConnection(testWorkloadId, nc)
 
-	service, _ := NewObjectStoreService(nc, slog.Default())
+	service, _ := NewObjectStoreService(slog.Default())
 	_ = server.AddService("objectstore", service, []byte{})
 	_ = server.Start()
 

--- a/host-services/builtins/http.go
+++ b/host-services/builtins/http.go
@@ -23,13 +23,11 @@ const defaultHTTPRequestTimeoutMillis = 2500
 
 type HTTPService struct {
 	log *slog.Logger
-	nc  *nats.Conn
 }
 
-func NewHTTPService(nc *nats.Conn, log *slog.Logger) (*HTTPService, error) {
+func NewHTTPService(log *slog.Logger) (*HTTPService, error) {
 	http := &HTTPService{
 		log: log,
-		nc:  nc,
 	}
 
 	return http, nil
@@ -39,7 +37,9 @@ func (h *HTTPService) Initialize(_ json.RawMessage) error {
 	return nil
 }
 
-func (h *HTTPService) HandleRequest(namespace string,
+func (h *HTTPService) HandleRequest(
+	_ *nats.Conn,
+	namespace string,
 	workloadId string,
 	method string,
 	workloadName string,

--- a/host-services/client.go
+++ b/host-services/client.go
@@ -12,16 +12,16 @@ import (
 )
 
 type HostServicesClient struct {
-	nc           *nats.Conn
+	ncInternal   *nats.Conn
 	namespace    string
 	workloadName string
 	workloadId   string
 	timeout      time.Duration
 }
 
-func NewHostServicesClient(nc *nats.Conn, timeout time.Duration, namespace, workloadName, workloadId string) *HostServicesClient {
+func NewHostServicesClient(ncInternal *nats.Conn, timeout time.Duration, namespace, workloadName, workloadId string) *HostServicesClient {
 	return &HostServicesClient{
-		nc:           nc,
+		ncInternal:   ncInternal,
 		namespace:    namespace,
 		workloadName: workloadName,
 		workloadId:   workloadId,
@@ -47,7 +47,7 @@ func (c *HostServicesClient) PerformRPC(ctx context.Context, service string, met
 
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(msg.Header))
 
-	result, err := c.nc.RequestMsg(msg, c.timeout)
+	result, err := c.ncInternal.RequestMsg(msg, c.timeout)
 	if err != nil {
 		return ServiceResult{}, err
 	}

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -36,6 +36,7 @@ func NewHostServicesServer(ncInternal *nats.Conn, log *slog.Logger, tracer trace
 }
 
 func (h *HostServicesServer) SetHostServicesConnection(workloadId string, nc *nats.Conn) {
+	h.RemoveHostServicesConnection(workloadId)
 	h.hsClientConnections[workloadId] = nc
 }
 

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -15,18 +15,34 @@ import (
 )
 
 type HostServicesServer struct {
-	log      *slog.Logger
-	nc       *nats.Conn
-	services map[string]HostService
-	tracer   trace.Tracer
+	log        *slog.Logger
+	ncInternal *nats.Conn
+	services   map[string]HostService
+	// Every single workload gets its own private host services connection,
+	// even if it's reusing defaults for config
+	hsClientConnections map[string]*nats.Conn
+
+	tracer trace.Tracer
 }
 
-func NewHostServicesServer(nc *nats.Conn, log *slog.Logger, tracer trace.Tracer) *HostServicesServer {
+func NewHostServicesServer(ncInternal *nats.Conn, log *slog.Logger, tracer trace.Tracer) *HostServicesServer {
 	return &HostServicesServer{
-		log:      log,
-		nc:       nc,
-		services: make(map[string]HostService),
-		tracer:   tracer,
+		log:                 log,
+		ncInternal:          ncInternal,
+		services:            make(map[string]HostService),
+		hsClientConnections: make(map[string]*nats.Conn),
+		tracer:              tracer,
+	}
+}
+
+func (h *HostServicesServer) SetHostServicesConnection(workloadId string, nc *nats.Conn) {
+	h.hsClientConnections[workloadId] = nc
+}
+
+func (h *HostServicesServer) RemoveHostServicesConnection(workloadId string) {
+	if c, ok := h.hsClientConnections[workloadId]; ok {
+		_ = c.Drain()
+		delete(h.hsClientConnections, workloadId)
 	}
 }
 
@@ -55,13 +71,13 @@ func (h *HostServicesServer) AddService(name string, svc HostService, config jso
 //
 // - hostint.<agent_id>.rpc.<namespace>.<workloadName>.<service>.<method>
 func (h *HostServicesServer) Start() error {
-	_, err := h.nc.Subscribe("hostint.*.rpc.*.*.*.*", h.handleRPC)
+	_, err := h.ncInternal.Subscribe("hostint.*.rpc.*.*.*.*", h.handleRPC)
 	if err != nil {
 		h.log.Warn("Failed to create Host services rpc subscription", slog.String("error", err.Error()))
 		return err
 	}
 
-	h.log.Debug("Host services rpc subscription created", slog.String("address", h.nc.ConnectedAddr()))
+	h.log.Debug("Host services rpc subscription created", slog.String("address", h.ncInternal.ConnectedAddr()))
 	return nil
 }
 
@@ -107,7 +123,9 @@ func (h *HostServicesServer) handleRPC(msg *nats.Msg) {
 
 	span.AddEvent("RPC Request Began")
 
-	result, err := service.HandleRequest(namespace, vmID, method, workloadName, metadata, msg.Data)
+	requestConnection := h.hsClientConnections[vmID]
+
+	result, err := service.HandleRequest(requestConnection, namespace, vmID, method, workloadName, metadata, msg.Data)
 	if err != nil {
 		h.log.Warn("Failed to handle host service RPC request",
 			slog.String("workload_id", vmID),

--- a/host-services/service.go
+++ b/host-services/service.go
@@ -3,6 +3,8 @@ package hostservices
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/nats-io/nats.go"
 )
 
 const (
@@ -45,6 +47,7 @@ type HostService interface {
 	Initialize(json.RawMessage) error
 
 	HandleRequest(
+		connection *nats.Conn,
 		namespace string,
 		workloadId string,
 		method string,

--- a/host-services/service_test.go
+++ b/host-services/service_test.go
@@ -125,7 +125,9 @@ func (b *bogusService) Initialize(config json.RawMessage) error {
 	return nil
 }
 
-func (b *bogusService) HandleRequest(namespace string,
+func (b *bogusService) HandleRequest(
+	conn *nats.Conn,
+	namespace string,
 	workloadId string,
 	method string,
 	workloadName string,

--- a/internal/agent-api/types.go
+++ b/internal/agent-api/types.go
@@ -44,19 +44,20 @@ type ExecutionProviderParams struct {
 
 // DeployRequest processed by the agent
 type DeployRequest struct {
-	Argv            []string               `json:"argv,omitempty"`
-	DecodedClaims   jwt.GenericClaims      `json:"-"`
-	Description     *string                `json:"description"`
-	Environment     map[string]string      `json:"environment"`
-	Essential       *bool                  `json:"essential,omitempty"`
-	Hash            string                 `json:"hash,omitempty"`
-	Namespace       *string                `json:"namespace,omitempty"`
-	RetriedAt       *time.Time             `json:"retried_at,omitempty"`
-	RetryCount      *uint                  `json:"retry_count,omitempty"`
-	TotalBytes      int64                  `json:"total_bytes,omitempty"`
-	TriggerSubjects []string               `json:"trigger_subjects"`
-	WorkloadName    *string                `json:"workload_name,omitempty"`
-	WorkloadType    controlapi.NexWorkload `json:"workload_type,omitempty"`
+	Argv               []string                              `json:"argv,omitempty"`
+	DecodedClaims      jwt.GenericClaims                     `json:"-"`
+	Description        *string                               `json:"description"`
+	Environment        map[string]string                     `json:"environment"`
+	Essential          *bool                                 `json:"essential,omitempty"`
+	Hash               string                                `json:"hash,omitempty"`
+	Namespace          *string                               `json:"namespace,omitempty"`
+	RetriedAt          *time.Time                            `json:"retried_at,omitempty"`
+	RetryCount         *uint                                 `json:"retry_count,omitempty"`
+	TotalBytes         int64                                 `json:"total_bytes,omitempty"`
+	TriggerSubjects    []string                              `json:"trigger_subjects"`
+	WorkloadName       *string                               `json:"workload_name,omitempty"`
+	WorkloadType       controlapi.NexWorkload                `json:"workload_type,omitempty"`
+	HostServicesConfig *controlapi.HostServicesConfiguration `json:"host_services,omitempty"`
 
 	Stderr      io.Writer `json:"-"`
 	Stdout      io.Writer `json:"-"`

--- a/internal/models/cli.go
+++ b/internal/models/cli.go
@@ -81,6 +81,10 @@ type RunOptions struct {
 	Essential         bool
 	DevMode           bool
 	TriggerSubjects   []string
+
+	HsUrl      string
+	HsUserJwt  string
+	HsUserSeed string
 }
 
 type StopOptions struct {

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -39,10 +39,12 @@ var (
 type NodeConfiguration struct {
 	AgentHandshakeTimeoutMillisecond int                      `json:"agent_handshake_timeout_ms,omitempty"`
 	AgentPingTimeoutMillisecond      int                      `json:"agent_ping_timeout_ms,omitempty"`
+	AutostartConfiguration           *AutostartConfig         `json:"autostart,omitempty"`
 	BinPath                          []string                 `json:"bin_path"`
 	CNI                              CNIDefinition            `json:"cni"`
 	DefaultResourceDir               string                   `json:"default_resource_dir"`
 	ForceDepInstall                  bool                     `json:"-"`
+	HostServicesConfiguration        *HostServicesConfig      `json:"host_services,omitempty"`
 	InternalNodeHost                 *string                  `json:"internal_node_host,omitempty"`
 	InternalNodePort                 *int                     `json:"internal_node_port"`
 	KernelFilepath                   string                   `json:"kernel_filepath"`
@@ -61,8 +63,6 @@ type NodeConfiguration struct {
 	Tags                             map[string]string        `json:"tags,omitempty"`
 	ValidIssuers                     []string                 `json:"valid_issuers,omitempty"`
 	WorkloadTypes                    []controlapi.NexWorkload `json:"workload_types,omitempty"`
-	HostServicesConfiguration        *HostServicesConfig      `json:"host_services,omitempty"`
-	AutostartConfiguration           *AutostartConfig         `json:"autostart,omitempty"`
 
 	// Public NATS server options; when non-nil, a public "userland" NATS server is started during node init
 	PublicNATSServer *server.Options `json:"public_nats_server,omitempty"`
@@ -70,6 +70,7 @@ type NodeConfiguration struct {
 	Errors []error `json:"errors,omitempty"`
 }
 
+// FIXME-- these properties should probably be *string 👀
 type HostServicesConfig struct {
 	NatsUrl      string                   `json:"nats_url"`
 	NatsUserJwt  string                   `json:"nats_user_jwt"`

--- a/internal/node/controlapi.go
+++ b/internal/node/controlapi.go
@@ -306,6 +306,7 @@ func (api *ApiListener) handleDeploy(m *nats.Msg) {
 		SenderPublicKey:      request.SenderPublicKey,
 		TargetNode:           request.TargetNode,
 		TotalBytes:           int64(numBytes),
+		HostServicesConfig:   request.HostServicesConfig,
 		TriggerSubjects:      request.TriggerSubjects,
 		WorkloadName:         &request.DecodedClaims.Subject,
 		WorkloadType:         request.WorkloadType, // FIXME-- audit all types for string -> *string, and validate...

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -75,7 +75,8 @@ func NewNode(
 	nodeOpts *models.NodeOptions,
 	ctx context.Context,
 	cancelF context.CancelFunc,
-	log *slog.Logger) (*Node, error) {
+	log *slog.Logger,
+) (*Node, error) {
 	node := &Node{
 		ctx:      ctx,
 		cancelF:  cancelF,

--- a/internal/node/services.go
+++ b/internal/node/services.go
@@ -20,25 +20,22 @@ const hostServiceObjectStore = "objectstore"
 // exposed to workloads by way of the agent which makes RPC calls
 // via the internal NATS connection
 type HostServices struct {
-	config         *models.HostServicesConfig
-	log            *slog.Logger
-	ncHostServices *nats.Conn
-	ncint          *nats.Conn
-	server         *hs.HostServicesServer
+	config *models.HostServicesConfig
+	log    *slog.Logger
+	ncint  *nats.Conn
+	server *hs.HostServicesServer
 }
 
 func NewHostServices(
 	ncint *nats.Conn,
-	ncHostServices *nats.Conn,
 	config *models.HostServicesConfig,
 	log *slog.Logger,
 	tracer trace.Tracer,
 ) *HostServices {
 	return &HostServices{
-		config:         config,
-		log:            log,
-		ncHostServices: ncHostServices,
-		ncint:          ncint,
+		config: config,
+		log:    log,
+		ncint:  ncint,
 		// ‼️ It cannot be overstated how important it is that the host services server
 		// be given the -internal- NATS connection and -not- the external/control one
 		//
@@ -51,7 +48,7 @@ func NewHostServices(
 func (h *HostServices) init() error {
 	if httpConfig, ok := h.config.Services[hostServiceHTTP]; ok {
 		if httpConfig.Enabled {
-			http, err := builtins.NewHTTPService(h.ncHostServices, h.log)
+			http, err := builtins.NewHTTPService(h.log)
 			if err != nil {
 				h.log.Error(fmt.Sprintf("failed to initialize http host service: %s", err.Error()))
 				return err
@@ -68,7 +65,7 @@ func (h *HostServices) init() error {
 
 	if kvConfig, ok := h.config.Services[hostServiceKeyValue]; ok {
 		if kvConfig.Enabled {
-			kv, err := builtins.NewKeyValueService(h.ncHostServices, h.log)
+			kv, err := builtins.NewKeyValueService(h.log)
 			if err != nil {
 				h.log.Error(fmt.Sprintf("failed to initialize key/value host service: %s", err.Error()))
 				return err
@@ -85,7 +82,7 @@ func (h *HostServices) init() error {
 
 	if messagingConfig, ok := h.config.Services[hostServiceMessaging]; ok {
 		if messagingConfig.Enabled {
-			messaging, err := builtins.NewMessagingService(h.ncHostServices, h.log)
+			messaging, err := builtins.NewMessagingService(h.log)
 			if err != nil {
 				h.log.Error(fmt.Sprintf("failed to initialize messaging host service: %s", err.Error()))
 				return err
@@ -102,7 +99,7 @@ func (h *HostServices) init() error {
 
 	if objectConfig, ok := h.config.Services[hostServiceObjectStore]; ok {
 		if objectConfig.Enabled {
-			object, err := builtins.NewObjectStoreService(h.ncHostServices, h.log)
+			object, err := builtins.NewObjectStoreService(h.log)
 			if err != nil {
 				h.log.Error(fmt.Sprintf("failed to initialize object store host service: %s", err.Error()))
 				return err

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -51,10 +51,9 @@ type WorkloadManager struct {
 	ctx     context.Context
 	t       *observability.Telemetry
 
-	nc             *nats.Conn
-	natsint        *internalnats.InternalNatsServer
-	ncint          *nats.Conn
-	ncHostServices *nats.Conn
+	nc      *nats.Conn
+	natsint *internalnats.InternalNatsServer
+	ncint   *nats.Conn
 
 	procMan processmanager.ProcessManager
 
@@ -128,15 +127,7 @@ func NewWorkloadManager(
 		w.log.Info("Internal NATS server started", slog.String("client_url", w.natsint.ClientURL()))
 	}
 
-	err = w.startHostServicesNATSConnection()
-	if err != nil {
-		w.log.Error("Failed to start host services NATS connection", slog.Any("error", err))
-		return nil, err
-	} else {
-		w.log.Info("Established host services NATS connection", slog.String("server", w.ncHostServices.Servers()[0]))
-	}
-
-	w.hostServices = NewHostServices(w.ncint, w.ncHostServices, config.HostServicesConfiguration, w.log, w.t.Tracer)
+	w.hostServices = NewHostServices(w.ncint, config.HostServicesConfiguration, w.log, w.t.Tracer)
 	err = w.hostServices.init()
 	if err != nil {
 		w.log.Warn("Failed to initialize host services", slog.Any("err", err))
@@ -242,9 +233,19 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 		w.activeAgents[workloadID] = agentClient
 		delete(w.pendingAgents, workloadID)
 
+		ncHostServices, err := w.createHostServicesConnection(request)
+		if err != nil {
+			w.log.Error("Failed to establish host services connection for workload",
+				slog.Any("error", err),
+			)
+			return err
+		}
+
+		w.hostServices.server.SetHostServicesConnection(workloadID, ncHostServices)
+
 		if request.SupportsTriggerSubjects() {
 			for _, tsub := range request.TriggerSubjects {
-				sub, err := w.nc.Subscribe(tsub, w.generateTriggerHandler(workloadID, tsub, request))
+				sub, err := ncHostServices.Subscribe(tsub, w.generateTriggerHandler(workloadID, tsub, request))
 				if err != nil {
 					w.log.Error("Failed to create trigger subject subscription for deployed workload",
 						slog.String("workload_id", workloadID),
@@ -377,6 +378,7 @@ func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
 		delete(w.activeAgents, id)
 		delete(w.pendingAgents, id)
 		delete(w.stopMutex, id)
+		w.hostServices.server.RemoveHostServicesConnection(id)
 
 		_ = w.publishWorkloadStopped(id)
 	}()
@@ -588,36 +590,45 @@ func (w *WorkloadManager) startInternalNATS() error {
 	return nil
 }
 
-func (w *WorkloadManager) startHostServicesNATSConnection() error {
-	if w.config.HostServicesConfiguration != nil {
-		if w.config.HostServicesConfiguration.NatsUrl == "" {
-			w.config.HostServicesConfiguration.NatsUrl = w.nc.Servers()[0]
-			w.ncHostServices = w.nc
-		} else {
-			natsOpts := []nats.Option{
-				nats.Name("nex-hostservices"),
-			}
-			if w.config.HostServicesConfiguration.NatsUserJwt == "" {
-				natsOpts = append(natsOpts,
-					nats.UserJWTAndSeed(
-						w.config.HostServicesConfiguration.NatsUserJwt,
-						w.config.HostServicesConfiguration.NatsUserSeed,
-					),
-				)
-			}
+func (w *WorkloadManager) createHostServicesConnection(request *agentapi.DeployRequest) (*nats.Conn, error) {
 
-			var err error
-			w.ncHostServices, err = nats.Connect(w.config.HostServicesConfiguration.NatsUrl, natsOpts...)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		w.ncHostServices = w.nc
+	natsOpts := []nats.Option{
+		nats.Name("nex-hostservices"),
 	}
 
-	w.log.Debug("Configured NATS connection for host services", slog.String("url", w.ncHostServices.Servers()[0]))
-	return nil
+	var url string
+	if request.HostServicesConfig != nil {
+		natsOpts = append(natsOpts,
+			nats.UserJWTAndSeed(request.HostServicesConfig.NatsUserJwt,
+				request.HostServicesConfig.NatsUserSeed,
+			))
+		url = request.HostServicesConfig.NatsUrl
+	} else if w.config.HostServicesConfiguration != nil {
+		natsOpts = append(natsOpts,
+			nats.UserJWTAndSeed(w.config.HostServicesConfiguration.NatsUserJwt,
+				w.config.HostServicesConfiguration.NatsUserSeed,
+			))
+		url = w.config.HostServicesConfiguration.NatsUrl
+	} else {
+		if w.nc.Opts.UserJWT != nil {
+			natsOpts = append(natsOpts,
+				nats.UserJWT(w.nc.Opts.UserJWT, w.nc.Opts.SignatureCB),
+			)
+		}
+		url = w.nc.Opts.Url
+	}
+
+	nc, err := nats.Connect(url, natsOpts...)
+	if err != nil {
+		return nil, err
+	}
+	w.log.Info("Established host services connection for workload",
+		slog.String("workload_name", *request.WorkloadName),
+		slog.String("url", nc.ConnectedUrl()),
+	)
+
+	return nc, nil
+
 }
 
 // Picks a pending agent from the pool that will receive the next deployment

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -614,7 +614,7 @@ func (w *WorkloadManager) createHostServicesConnection(request *agentapi.DeployR
 		if w.config.HostServicesConfiguration.NatsUrl != "" {
 			url = w.config.HostServicesConfiguration.NatsUrl
 		} else {
-			url = w.nc.Opts.Url
+			url = w.nc.Servers()[0]
 		}
 	} else {
 		if w.nc.Opts.UserJWT != nil {

--- a/nex/nex.go
+++ b/nex/nex.go
@@ -110,6 +110,9 @@ func init() {
 	run.Flag("argv", "Arguments to pass to the workload, if applicable").StringVar(&RunOpts.Argv)
 	run.Flag("essential", "When true, workload is redeployed if it exits with a non-zero status").BoolVar(&RunOpts.Essential)
 	run.Flag("trigger_subject", "Trigger subjects to register for subsequent workload execution, if supported by the workload type").StringsVar(&RunOpts.TriggerSubjects)
+	run.Flag("hs_url", "Override the URL used for host services for this workload").StringVar(&RunOpts.HsUrl)
+	run.Flag("hs_jwt", "Set the user JWT for override host services connection").StringVar(&RunOpts.HsUserJwt)
+	run.Flag("hs_seed", "Set the user seed for override host services connection").StringVar(&RunOpts.HsUserSeed)
 
 	yeet.Arg("file", "File to run").Required().ExistingFileVar(&DevRunOpts.Filename)
 	yeet.Arg("env", "Environment variables to pass to workload").StringMapVar(&RunOpts.Env)


### PR DESCRIPTION
Each workload is now given its own unique/private host services connection. These connections are created using the following order of configuration (1 being the highest priority)

1. host services configuration on the deployment request
2. host services configuration supplied for the entire node
3. configuration copied from the node's control connection