### PR TITLE
Use configured CNI subnet to lockdown DNS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.2
 
 require (
 	dagger.io/dagger v0.11.2
+	github.com/3th1nk/cidr v0.2.0
 	github.com/cdfmlr/ellipsis v0.0.1
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRq
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 dagger.io/dagger v0.11.2 h1:HoDAk1GZ676ziC/aNB4JX5tJbXhJ63ydBEo/oDacxJo=
 dagger.io/dagger v0.11.2/go.mod h1:ABrEbaXuGQtqOlc0WlHWHQt/azY0jEs/O/X8xkX8xxM=
+github.com/3th1nk/cidr v0.2.0 h1:81jjEknszD8SHPLVTPPk+BZjNVqq1ND2YXLSChl6Lrs=
+github.com/3th1nk/cidr v0.2.0/go.mod h1:XsSQnS4rEYyB2veDfnIGgViulFpIITPKtp3f0VxpiLw=
 github.com/99designs/gqlgen v0.17.45 h1:bH0AH67vIJo8JKNKPJP+pOPpQhZeuVRQLf53dKIpDik=
 github.com/99designs/gqlgen v0.17.45/go.mod h1:Bas0XQ+Jiu/Xm5E33jC8sES3G+iC2esHBMXcq0fUPs0=
 github.com/Azure/azure-sdk-for-go v30.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -355,6 +357,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/internal/node/dns.go
+++ b/internal/node/dns.go
@@ -63,7 +63,9 @@ func NewDNS(log *slog.Logger, config *models.NodeConfiguration) (*DNS, error) {
 	}
 
 	if config.CNI.Subnet != nil {
-		go d.lockdown(*config.CNI.Subnet)
+		go func() {
+			_ = d.lockdown(*config.CNI.Subnet)
+		}()
 	}
 
 	return d, nil

--- a/internal/node/dns.go
+++ b/internal/node/dns.go
@@ -57,16 +57,6 @@ func NewDNS(log *slog.Logger, config *models.NodeConfiguration) (*DNS, error) {
 
 	d.handler.Handle(".", d) // recursive resolver
 
-	// d.server = &dns.Server{
-	// 	Handler:      d.handler,
-	// 	Listener:     nil, // FIXME-- to support TCP, set Listener
-	// 	PacketConn:   d.udp,
-	// 	ReadTimeout:  time.Hour,
-	// 	WriteTimeout: time.Hour,
-	// }
-
-	// d.handler.Handle(".", d) // recursive resolver
-
 	err = d.Start()
 	if err != nil {
 		return nil, err
@@ -211,7 +201,7 @@ func (d *DNS) lockdown(subnet string) error {
 
 	err = d.Stop()
 	if err != nil {
-		d.log.Warn("failed to stop DNS", slog.String("error", err.Error()))
+		d.log.Warn("Failed to lockdown DNS server", slog.String("error", err.Error()))
 		return err
 	}
 
@@ -251,6 +241,8 @@ func (d *DNS) lockdown(subnet string) error {
 
 		// TODO? -- currently only udp is implemented -- reuse the ephemeral UDP port for a second TCP listener...
 		// tcpAddr := tcp.Addr().String() -- this will actually be == udpAddr if implemented
+
+		time.Sleep(time.Millisecond * 25)
 	}
 
 	d.log.Debug("Locked down DNS server")

--- a/internal/node/dns.go
+++ b/internal/node/dns.go
@@ -69,18 +69,6 @@ func NewDNS(log *slog.Logger, config *models.NodeConfiguration) (*DNS, error) {
 	return d, nil
 }
 
-func (d *DNS) initServer() error {
-	d.server = &dns.Server{
-		Handler:      d.handler,
-		Listener:     nil, // FIXME-- to support TCP, set Listener
-		PacketConn:   d.udp,
-		ReadTimeout:  time.Hour,
-		WriteTimeout: time.Hour,
-	}
-
-	return d.Start()
-}
-
 func (d *DNS) Add(pattern string, ipaddr string) {
 	d.handler.HandleFunc(pattern, func(w dns.ResponseWriter, r *dns.Msg) {
 		d.log.Debug("Received DNS query for matching pattern", slog.String("msg", r.String()), slog.String("a", ipaddr))

--- a/internal/node/dns.go
+++ b/internal/node/dns.go
@@ -5,13 +5,18 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/3th1nk/cidr"
 	"github.com/miekg/dns"
+	"github.com/synadia-io/nex/internal/models"
 )
 
 const defaultNameserver = "127.0.0.53:53"
+const defaultDNSListenTimeoutMillis = 5000
 
 // DNS manages the lifecycle of a local nameserver that functions as
 // a resolver for local DNS names and a recursive resolver when a DNS
@@ -29,7 +34,7 @@ type DNS struct {
 	udpAddr *string
 }
 
-func NewDNS(log *slog.Logger) (*DNS, error) {
+func NewDNS(log *slog.Logger, config *models.NodeConfiguration) (*DNS, error) {
 	udp, err := net.ListenPacket("udp", ":0")
 	if err != nil {
 		return nil, err
@@ -50,6 +55,31 @@ func NewDNS(log *slog.Logger) (*DNS, error) {
 		udpAddr: &udpAddr,
 	}
 
+	d.handler.Handle(".", d) // recursive resolver
+
+	// d.server = &dns.Server{
+	// 	Handler:      d.handler,
+	// 	Listener:     nil, // FIXME-- to support TCP, set Listener
+	// 	PacketConn:   d.udp,
+	// 	ReadTimeout:  time.Hour,
+	// 	WriteTimeout: time.Hour,
+	// }
+
+	// d.handler.Handle(".", d) // recursive resolver
+
+	err = d.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	if config.CNI.Subnet != nil {
+		go d.lockdown(*config.CNI.Subnet)
+	}
+
+	return d, nil
+}
+
+func (d *DNS) initServer() error {
 	d.server = &dns.Server{
 		Handler:      d.handler,
 		Listener:     nil, // FIXME-- to support TCP, set Listener
@@ -58,14 +88,7 @@ func NewDNS(log *slog.Logger) (*DNS, error) {
 		WriteTimeout: time.Hour,
 	}
 
-	d.handler.Handle(".", d) // recursive resolver
-
-	err = d.Start()
-	if err != nil {
-		return nil, err
-	}
-
-	return d, nil
+	return d.Start()
 }
 
 func (d *DNS) Add(pattern string, ipaddr string) {
@@ -131,6 +154,14 @@ func (d *DNS) Start() error {
 	mutex := sync.Mutex{}
 	mutex.Lock()
 
+	d.server = &dns.Server{
+		Handler:      d.handler,
+		Listener:     nil, // FIXME-- to support TCP, set Listener
+		PacketConn:   d.udp,
+		ReadTimeout:  time.Hour,
+		WriteTimeout: time.Hour,
+	}
+
 	d.server.NotifyStartedFunc = mutex.Unlock
 
 	if d.tcp != nil {
@@ -159,5 +190,70 @@ func (d *DNS) Start() error {
 
 func (d *DNS) Stop() error {
 	d.log.Info("DNS nameserver stopping")
-	return d.server.Shutdown()
+
+	err := d.server.Shutdown()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DNS) lockdown(subnet string) error {
+	ips, err := cidr.Parse(subnet)
+	if err != nil {
+		return err
+	}
+
+	var addr net.IP
+	addr, _ = ips.IPRange()
+	cidr.IPIncr(addr)
+
+	err = d.Stop()
+	if err != nil {
+		d.log.Warn("failed to stop DNS", slog.String("error", err.Error()))
+		return err
+	}
+
+	d.closers = make([]io.Closer, 0)
+	d.exit = make(chan error, 1)
+	d.server = nil
+
+	deadline := time.Now().Add(time.Millisecond * defaultDNSListenTimeoutMillis)
+	for time.Now().Before(deadline) {
+		udpAddr := strings.Split(*d.udpAddr, ":")
+		port, err := strconv.Atoi(udpAddr[len(udpAddr)-1])
+		if err != nil {
+			d.log.Warn("Failed to lockdown DNS server; failed to parse port", slog.String("error", err.Error()))
+			return err
+		}
+
+		udp, err := net.ListenPacket("udp", fmt.Sprintf("%s:%d", addr.String(), port))
+		if err != nil {
+			d.log.Warn("Failed to lockdown DNS server", slog.String("error", err.Error()))
+		}
+
+		if err == nil {
+			d.log.Debug("UDP listener bound for lockdown", slog.String("addr", udp.LocalAddr().String()))
+
+			d.udp = udp
+			udpAddr := d.udp.LocalAddr().String()
+			d.udpAddr = &udpAddr
+
+			err = d.Start()
+			if err != nil {
+				d.log.Warn("Failed to lockdown DNS server", slog.String("error", err.Error()))
+				return err
+			}
+
+			break
+		}
+
+		// TODO? -- currently only udp is implemented -- reuse the ephemeral UDP port for a second TCP listener...
+		// tcpAddr := tcp.Addr().String() -- this will actually be == udpAddr if implemented
+	}
+
+	d.log.Debug("Locked down DNS server")
+
+	return nil
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -244,7 +244,7 @@ func (n *Node) init() error {
 
 		if !n.config.NoSandbox {
 			// setup DNS nameserver
-			n.dns, err = NewDNS(n.log)
+			n.dns, err = NewDNS(n.log, n.config)
 			if err != nil {
 				n.log.Error("Failed to initialize DNS nameserver", slog.Any("err", err))
 				err = fmt.Errorf("failed to initialize DNS nameserver: %s", err)

--- a/spec/spec_suite_test.go
+++ b/spec/spec_suite_test.go
@@ -70,7 +70,7 @@ func cleanupFixtures() {
 
 	os.RemoveAll(_fixtures.natsStoreDir)
 
-	time.Sleep(time.Millisecond * 2500)
+	time.Sleep(time.Millisecond * 5000)
 }
 
 func startNATS(storeDir string) (*server.Server, *nats.Conn, *int, error) {


### PR DESCRIPTION
This PR prevents a nex host running the embedded DNS resolver from being used by other devices on the same network.

This implements some trickery to bind the UDP listener for DNS to the configured CNI gateway without regard to the presence of required network interfaces. Once the interface has been created, the UDP listener is rebound on the same ephemeral port and the listener originally created on 0.0.0.0 is closed.