### PR TITLE
relax restrictions on workload name

### DIFF
--- a/control-api/run.go
+++ b/control-api/run.go
@@ -48,8 +48,12 @@ type HostServicesConfiguration struct {
 	NatsUserSeed string `json:"nats_user_seed"`
 }
 
+const (
+	workloadRegex = `^[a-zA-Z0-9_-]+$`
+)
+
 var (
-	validWorkloadName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	validWorkloadName = regexp.MustCompile(workloadRegex)
 )
 
 // Creates a new deploy request based on the supplied options. Note that there is a fluent API function
@@ -102,7 +106,7 @@ func (request *DeployRequest) Validate() (*jwt.GenericClaims, error) {
 
 	request.DecodedClaims = *claims
 	if !validWorkloadName.MatchString(claims.Subject) {
-		return nil, fmt.Errorf("workload name claim ('%s') does not match requirements (alphanumeric or underscore)", claims.Subject)
+		return nil, fmt.Errorf("workload name claim ('%s') does not match requirements (%s)", claims.Subject, workloadRegex)
 	}
 
 	var vr jwt.ValidationResults

--- a/control-api/run.go
+++ b/control-api/run.go
@@ -49,7 +49,7 @@ type HostServicesConfiguration struct {
 }
 
 var (
-	validWorkloadName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+	validWorkloadName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 )
 
 // Creates a new deploy request based on the supplied options. Note that there is a fluent API function

--- a/control-api/run.go
+++ b/control-api/run.go
@@ -49,7 +49,7 @@ type HostServicesConfiguration struct {
 }
 
 var (
-	validWorkloadName = regexp.MustCompile(`^[a-z]+$`)
+	validWorkloadName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 )
 
 // Creates a new deploy request based on the supplied options. Note that there is a fluent API function
@@ -102,7 +102,7 @@ func (request *DeployRequest) Validate() (*jwt.GenericClaims, error) {
 
 	request.DecodedClaims = *claims
 	if !validWorkloadName.MatchString(claims.Subject) {
-		return nil, fmt.Errorf("workload name claim ('%s') does not match requirements of all lowercase letters", claims.Subject)
+		return nil, fmt.Errorf("workload name claim ('%s') does not match requirements (alphanumeric or underscore)", claims.Subject)
 	}
 
 	var vr jwt.ValidationResults


### PR DESCRIPTION
Allows capital letters and underscores now as well as the original letters and numbers.