### PR TITLE
fixes bug in gather processing

### DIFF
--- a/control-api/client.go
+++ b/control-api/client.go
@@ -128,6 +128,9 @@ func (api *Client) PingWorkloads(workloadID string) ([]WorkloadPingResponse, err
 	responses := make([]WorkloadPingResponse, 0)
 
 	sub, err := api.nc.Subscribe(api.nc.NewRespInbox(), func(m *nats.Msg) {
+		if len(m.Data) == 0 {
+			return
+		}
 		env, err := extractEnvelope(m.Data)
 		if err != nil {
 			return
@@ -172,6 +175,9 @@ func (api *Client) Auction(req *AuctionRequest) ([]AuctionResponse, error) {
 	responses := make([]AuctionResponse, 0)
 
 	sub, err := api.nc.Subscribe(api.nc.NewRespInbox(), func(m *nats.Msg) {
+		if len(m.Data) == 0 {
+			return
+		}
 		env, err := extractEnvelope(m.Data)
 		if err != nil {
 			api.log.Error("failed to extract envelope", slog.Any("err", err), slog.Any("nats_msg.Data", m.Data))
@@ -224,6 +230,9 @@ func (api *Client) PingNodes() ([]PingResponse, error) {
 	responses := make([]PingResponse, 0)
 
 	sub, err := api.nc.Subscribe(api.nc.NewRespInbox(), func(m *nats.Msg) {
+		if len(m.Data) == 0 {
+			return
+		}
 		env, err := extractEnvelope(m.Data)
 		if err != nil {
 			api.log.Error("failed to extract envelope", slog.Any("err", err), slog.Any("nats_msg.Data", m.Data))


### PR DESCRIPTION
This bug didn't show up when using the `nex` CLI directly because the CLI creates an empty/discard logger. When using the library with a logger, we'd constantly see:

```
[ERROR] 08:49:00 - failed to extract envelope err=no data for envelope nats_msg.Data=[]
```

This is because all of the code in the nexus client responsible for gathering multiple responses didn't account for getting a response with no data (this happens when there's "no responders", etc)

The new code will skip all processing if there's no data to process.