### PR TITLE
Adds the ability to deny certain trigger subjects for functions

### DIFF
--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -26,7 +26,8 @@ const (
 )
 
 var (
-	DefaultWorkloadTypes = []controlapi.NexWorkload{controlapi.NexWorkloadNative}
+	RequiredTriggerSubjectDenyList = []string{"$SYS.>", "$JS.>", "$NEX.>"}
+	DefaultWorkloadTypes           = []controlapi.NexWorkload{controlapi.NexWorkloadNative}
 
 	DefaultBinPath = append([]string{"/usr/local/bin"}, filepath.SplitList(os.Getenv("PATH"))...)
 
@@ -63,6 +64,7 @@ type NodeConfiguration struct {
 	Tags                             map[string]string        `json:"tags,omitempty"`
 	ValidIssuers                     []string                 `json:"valid_issuers,omitempty"`
 	WorkloadTypes                    []controlapi.NexWorkload `json:"workload_types,omitempty"`
+	DenyTriggerSubjects              []string                 `json:"deny_trigger_subjects,omitempty"`
 
 	// Public NATS server options; when non-nil, a public "userland" NATS server is started during node init
 	PublicNATSServer *server.Options `json:"public_nats_server,omitempty"`

--- a/internal/node/config.go
+++ b/internal/node/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	controlapi "github.com/synadia-io/nex/control-api"
@@ -47,6 +48,12 @@ func LoadNodeConfiguration(configFilepath string) (*models.NodeConfiguration, er
 
 	if config.Tags == nil {
 		config.Tags = make(map[string]string)
+	}
+
+	for _, sub := range models.RequiredTriggerSubjectDenyList {
+		if !slices.Contains(config.DenyTriggerSubjects, sub) {
+			config.DenyTriggerSubjects = append(config.DenyTriggerSubjects, sub)
+		}
 	}
 
 	return &config, nil

--- a/internal/node/controlapi_test.go
+++ b/internal/node/controlapi_test.go
@@ -7,6 +7,25 @@ import (
 	controlapi "github.com/synadia-io/nex/control-api"
 )
 
+func TestDenyList(t *testing.T) {
+	denyList := []string{
+		"$SYS.>",
+		"$JS.>",
+	}
+
+	if !inDenyList("$SYS.this.is.a.test", denyList) {
+		t.Fatal("Should have subject collision in deny list but didn't")
+	}
+
+	if !inDenyList("$JS.foo.bar", denyList) {
+		t.Fatal("Should have subject collision in deny list but didn't")
+	}
+
+	if inDenyList("bob.test", denyList) {
+		t.Fatalf("Allowed subject was denied incorrectly")
+	}
+}
+
 func TestSummarizeMachinesForPing(t *testing.T) {
 	workloads := []controlapi.MachineSummary{
 		{

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -230,7 +230,10 @@ func (n *Node) init() error {
 			n.log.Error("Failed to load node configuration file", slog.Any("err", _err), slog.String("config_path", n.nodeOpts.ConfigFilepath))
 			err = errors.Join(err, _err)
 		} else {
-			n.log.Info("Loaded node configuration", slog.String("config_path", n.nodeOpts.ConfigFilepath))
+			n.log.Info("Loaded node configuration",
+				slog.String("config_path", n.nodeOpts.ConfigFilepath),
+				slog.Any("deny_trigger_subjects", n.config.DenyTriggerSubjects),
+			)
 		}
 
 		n.telemetry, _err = observability.NewTelemetry(n.ctx, n.log, n.config, n.publicKey)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -231,8 +231,7 @@ func (n *Node) init() error {
 			err = errors.Join(err, _err)
 		} else {
 			n.log.Info("Loaded node configuration",
-				slog.String("config_path", n.nodeOpts.ConfigFilepath),
-				slog.Any("deny_trigger_subjects", n.config.DenyTriggerSubjects),
+				slog.String("config_path", n.nodeOpts.ConfigFilepath)				
 			)
 		}
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -231,7 +231,7 @@ func (n *Node) init() error {
 			err = errors.Join(err, _err)
 		} else {
 			n.log.Info("Loaded node configuration",
-				slog.String("config_path", n.nodeOpts.ConfigFilepath)				
+				slog.String("config_path", n.nodeOpts.ConfigFilepath),
 			)
 		}
 


### PR DESCRIPTION
1. Always rejects a certain set of subject spaces for functions: `$SYS.>`, `$JS.>`, and `$NEX.>`. 
2. You can add more trigger subject restrictions in the node config using the `deny_trigger_subjects` field

This is what it looks like to try and devrun a function with a denied trigger subject:

```
❯ ./nex devrun ../examples/v8/echofunction/src/echofunction.js --trigger_subject='$NEX.events.>' --type=v8
Reusing existing issuer account key: /home/kevin/.nex/issuer.nk
Reusing existing publisher xkey: /home/kevin/.nex/publisher.xk
[ERR] 2024-06-18 14:21:56 - failed to devrun workload err=The trigger subject $NEX.events.> overlaps with subject(s) in this node's deny list
```