### PR TITLE
puts node-wide logs in the system namespace

### DIFF
--- a/nex/nex.go
+++ b/nex/nex.go
@@ -211,8 +211,8 @@ func main() {
 		}
 	}
 	if slices.Contains(Opts.Logger, "nats") {
-		natsLogSubject := fmt.Sprintf("$NEX.logs.%s.stdout", pk)
-		natsErrLogSubject := fmt.Sprintf("$NEX.logs.%s.stderr", pk)
+		natsLogSubject := fmt.Sprintf("$NEX.logs.system.%s.stdout", pk)
+		natsErrLogSubject := fmt.Sprintf("$NEX.logs.system.%s.stderr", pk)
 		nc, err := models.GenerateConnectionFromOpts(Opts, logger)
 		if err == nil {
 			defer func() {


### PR DESCRIPTION
for consistency so that a subscription to `$NEX.logs.{namespace}.>` will always end in a namespace, this adds the `system` token to the node-scoped logs that are emitted via the `stdout` and `stderr` tokens