### PR TITLE
fail fast autostarts

### DIFF
--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -96,6 +96,7 @@ type AutostartDeployRequest struct {
 	Namespace       string                 `json:"namespace"`
 	Argv            []string               `json:"argv,omitempty"`
 	Description     *string                `json:"description,omitempty"`
+	Essential       bool                   `json:"essential,omitempty"`
 	WorkloadType    controlapi.NexWorkload `json:"type"`
 	Location        string                 `json:"location"`
 	JsDomain        *string                `json:"jsdomain,omitempty"`

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -333,12 +333,6 @@ func (n *Node) handleAutostarts() {
 				n.log.Warn("Failed to resolve agent for autostart", slog.String("error", err.Error()))
 				time.Sleep(50 * time.Millisecond)
 			}
-			agentClient, err = n.manager.SelectRandomAgent()
-		}
-		if err != nil {
-			n.log.Error("No warm workload machine in pool for autostart. Node is in a bad state, will shut down",
-				slog.Any("error", err),
-			)
 		}
 
 		// functions cannot be essential

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -34,6 +34,7 @@ const (
 	publicNATSServerStartTimeout = 50 * time.Millisecond
 	runloopSleepInterval         = 100 * time.Millisecond
 	runloopTickInterval          = 2500 * time.Millisecond
+	agentPoolRetryMax            = 3
 )
 
 // Nex node process
@@ -323,15 +324,25 @@ func (n *Node) startPublicNATS() error {
 }
 
 func (n *Node) handleAutostarts() {
+	successCount := 0
 	for _, autostart := range n.config.AutostartConfiguration.Workloads {
 		var agentClient *agentapi.AgentClient
 		var err error
 
+		retry := 0
 		for agentClient == nil {
 			agentClient, err = n.manager.SelectRandomAgent()
 			if err != nil {
 				n.log.Warn("Failed to resolve agent for autostart", slog.String("error", err.Error()))
 				time.Sleep(50 * time.Millisecond)
+				retry += 1
+				if retry > agentPoolRetryMax {
+					n.log.Error("Exceeded warm agent retrieval retry count, terminating node",
+						slog.Int("allowed_retries", agentPoolRetryMax),
+					)
+					n.shutdown()
+					return
+				}
 			}
 		}
 
@@ -356,7 +367,7 @@ func (n *Node) handleAutostarts() {
 			n.log.Error("Failed to create deployment request for autostart workload",
 				slog.Any("error", err),
 			)
-			n.shutdown()
+			continue
 		}
 
 		if autostart.JsDomain != nil {
@@ -368,7 +379,7 @@ func (n *Node) handleAutostarts() {
 			n.log.Error("Failed to validate autostart deployment request",
 				slog.Any("error", err),
 			)
-			n.shutdown()
+			continue
 		}
 
 		// TODO: add potential backoff and retry to cacheworkload
@@ -380,7 +391,7 @@ func (n *Node) handleAutostarts() {
 				slog.String("namespace", autostart.Namespace),
 				slog.String("url", autostart.Location),
 			)
-			n.shutdown()
+			continue
 		}
 		agentDeployRequest := agentDeployRequestFromControlDeployRequest(request, autostart.Namespace, numBytes, *workloadHash)
 
@@ -394,12 +405,19 @@ func (n *Node) handleAutostarts() {
 				slog.String("name", autostart.Name),
 				slog.String("namespace", autostart.Namespace),
 			)
-			n.shutdown()
+			continue
 		}
 		n.log.Info("Autostart workload started",
 			slog.String("name", autostart.Name),
 			slog.String("namespace", autostart.Namespace),
 			slog.String("workload_id", agentClient.ID()),
+		)
+		successCount += 1
+	}
+	if successCount < len(n.config.AutostartConfiguration.Workloads) {
+		n.log.Error("Not all startup workloads suceeded",
+			slog.Int("expected", len(n.config.AutostartConfiguration.Workloads)),
+			slog.Int("actual", successCount),
 		)
 	}
 }


### PR DESCRIPTION
This will close #292 : 

1. Cause a node shutdown if any error occurs while trying to start an autostart workload
2. Can now indicate whether an autostart workload should be `essential` in the autostart portion of the node config.