### PR TITLE
adds optional node limits

### DIFF
--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -54,7 +54,8 @@ type AgentClient struct {
 	execTotalNanos    int64
 	workloadStartedAt time.Time
 
-	subz []*nats.Subscription
+	workloadBytes uint64
+	subz          []*nats.Subscription
 }
 
 func NewAgentClient(
@@ -153,7 +154,12 @@ func (a *AgentClient) DeployWorkload(request *DeployRequest) (*DeployResponse, e
 	}
 
 	a.workloadStartedAt = time.Now().UTC()
+	a.workloadBytes = uint64(request.TotalBytes)
 	return &deployResponse, nil
+}
+
+func (a *AgentClient) WorkloadBytes() uint64 {
+	return a.workloadBytes
 }
 
 // Draining subscriptions and release other resources associated

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -63,6 +63,7 @@ type NodeConfiguration struct {
 	ValidIssuers                     []string                 `json:"valid_issuers,omitempty"`
 	WorkloadTypes                    []controlapi.NexWorkload `json:"workload_types,omitempty"`
 	DenyTriggerSubjects              []string                 `json:"deny_trigger_subjects,omitempty"`
+	NodeLimits                       NodeLimitsConfig         `json:"node_limits"`
 
 	PreflightVerbose bool `json:"-"`
 	PreflightVerify  bool `json:"-"`
@@ -80,6 +81,12 @@ type HostServicesConfig struct {
 	NatsUserJwt  string                   `json:"nats_user_jwt"`
 	NatsUserSeed string                   `json:"nats_user_seed"`
 	Services     map[string]ServiceConfig `json:"services"`
+}
+
+type NodeLimitsConfig struct {
+	MaxWorkloads     int `json:"max_workloads"`
+	MaxTotalBytes    int `json:"max_total_bytes"`
+	MaxWorkloadBytes int `json:"max_workload_bytes"`
 }
 
 type ServiceConfig struct {

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -683,6 +683,15 @@ func (w *WorkloadManager) SelectRandomAgent() (*agentapi.AgentClient, error) {
 	return nil, nil
 }
 
+func (w *WorkloadManager) TotalRunningWorkloadBytes() uint64 {
+	total := uint64(0)
+	for _, c := range w.activeAgents {
+		total += c.WorkloadBytes()
+	}
+
+	return total
+}
+
 func createJwtConnection(info *controlapi.NatsJwtConnectionInfo) (*nats.Conn, error) {
 	natsOpts := []nats.Option{
 		nats.Name("workload-trigger-subscription"),


### PR DESCRIPTION
If a `node_limits` section is specified in the node configuration, then we can now specify the following limits:

* max bytes for an individual workload (disk size, not ram)
* max bytes total for the entire node
* max number of running workloads for the node, regardless of size