### PR TITLE
uses pool mutex to select random agent

### DIFF
--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -670,6 +670,9 @@ func (w *WorkloadManager) createHostServicesConnection(request *agentapi.DeployR
 
 // Picks a pending agent from the pool that will receive the next deployment
 func (w *WorkloadManager) SelectRandomAgent() (*agentapi.AgentClient, error) {
+	w.poolMutex.Lock()
+	defer w.poolMutex.Unlock()
+
 	if len(w.pendingAgents) == 0 {
 		return nil, errors.New("no available agent client in pool")
 	}


### PR DESCRIPTION
I genuinely don't know if this makes things better, worse, or has no effect. It's had no effect on the spec tests.

For consistency sake, the `SelectRandomAgent` was the only method that didn't honor the pool mutex, so I'm adding that in.