### PR TITLE
Add support for executing agent-local workloads

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -185,7 +185,7 @@ func (a *Agent) Version() string {
 func (a *Agent) resolveExecutableArtifact(req *agentapi.DeployRequest) (*string, error) {
 	var file *string
 
-	switch req.Location.Scheme {
+	switch strings.ToLower(req.Location.Scheme) {
 	case workloadLocationSchemeFile:
 		if !isSandboxed() {
 			return nil, fmt.Errorf("attempted to execute agent-local workload artifact %s outside of sandbox ", req.Location.String())

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -31,6 +31,9 @@ const (
 	runloopSleepInterval                = 250 * time.Millisecond
 	runloopTickInterval                 = 2500 * time.Millisecond
 	workloadExecutionSleepTimeoutMillis = 100
+	workloadCacheFileKey                = "workload"
+	workloadLocationSchemeFile          = "file"
+	workloadLocationSchemeNATS          = "nats"
 )
 
 // Agent facilitates communication between the nex agent running in the firecracker VM
@@ -168,33 +171,66 @@ func (a *Agent) Version() string {
 	return VERSION
 }
 
-// cacheExecutableArtifact uses the underlying agent configuration to fetch
-// the executable workload artifact from the cache bucket, write it to a
-// temporary file and make it executable; this method returns the full
-// path to the cached artifact if successful
-func (a *Agent) cacheExecutableArtifact(req *agentapi.DeployRequest) (*string, error) {
-	fileName := fmt.Sprintf("workload-%s", *a.md.VmID)
-	tempFile := path.Join(os.TempDir(), fileName)
+// resolveExecutableArtifact uses the underlying agent configuration and
+// location specified in the workload deploy request to prepare the workload
+// artifact for execution by the agent.
+//
+// in the case of the workload artifact being deployed from a nats:// location
+// this method fetches the workload artifact from the object store bucket,
+// writes it to a temporary file and makes it executable.
+//
+// in the case of the workload artifact being deployed from a file:// location,
+// this method verifies that the specified file exists on the agent rootfs and
+// is executable.
+func (a *Agent) resolveExecutableArtifact(req *agentapi.DeployRequest) (*string, error) {
+	var file *string
 
-	if strings.EqualFold(runtime.GOOS, "windows") && req.WorkloadType == controlapi.NexWorkloadNative {
-		tempFile = fmt.Sprintf("%s.exe", tempFile)
+	switch req.Location.Scheme {
+	case workloadLocationSchemeFile:
+		path, _ := strings.CutPrefix(req.Location.String(), fmt.Sprintf("%s://", workloadLocationSchemeFile))
+
+		fi, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("attempted to execute agent-local workload artifact %s; file does not exist: %s", path, err.Error())
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat agent-local workload artifact %s; %s", path, err.Error())
+		}
+
+		if fi.IsDir() {
+			return nil, fmt.Errorf("failed to execute agent-local workload artifact; %s is a directory", path)
+		} else if fi.Mode()&0111 == 0 {
+			return nil, fmt.Errorf("failed to execute agent-local workload artifact; %s is not executable", path)
+		}
+
+		file = &path
+	case workloadLocationSchemeNATS:
+		fileName := fmt.Sprintf("workload-%s", *a.md.VmID)
+		tempFile := path.Join(os.TempDir(), fileName)
+
+		if strings.EqualFold(runtime.GOOS, "windows") && req.WorkloadType == controlapi.NexWorkloadNative {
+			tempFile = fmt.Sprintf("%s.exe", tempFile)
+		}
+
+		err := a.cacheBucket.GetFile(workloadCacheFileKey, tempFile)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to get and write workload artifact to temp dir: %s", err)
+			a.LogError(msg)
+			return nil, errors.New(msg)
+		}
+
+		err = os.Chmod(tempFile, 0777)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to set workload artifact as executable: %s", err)
+			a.LogError(msg)
+			return nil, errors.New(msg)
+		}
+
+		file = &tempFile
 	}
 
-	err := a.cacheBucket.GetFile(*a.md.VmID, tempFile)
-	if err != nil {
-		msg := fmt.Sprintf("Failed to get and write workload artifact to temp dir: %s", err)
-		a.LogError(msg)
-		return nil, errors.New(msg)
-	}
-
-	err = os.Chmod(tempFile, 0777)
-	if err != nil {
-		msg := fmt.Sprintf("Failed to set workload artifact as executable: %s", err)
-		a.LogError(msg)
-		return nil, errors.New(msg)
-	}
-
-	return &tempFile, nil
+	return file, nil
 }
 
 // deleteExecutableArtifact deletes the installed workload executable
@@ -269,13 +305,13 @@ func (a *Agent) handleDeploy(m *nats.Msg) {
 		return
 	}
 
-	tmpFile, err := a.cacheExecutableArtifact(&request)
+	path, err := a.resolveExecutableArtifact(&request)
 	if err != nil {
 		_ = a.workAck(m, false, err.Error())
 		return
 	}
 
-	params, err := a.newExecutionProviderParams(&request, *tmpFile)
+	params, err := a.newExecutionProviderParams(&request, *path)
 	if err != nil {
 		_ = a.workAck(m, false, err.Error())
 		return

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -187,6 +187,10 @@ func (a *Agent) resolveExecutableArtifact(req *agentapi.DeployRequest) (*string,
 
 	switch req.Location.Scheme {
 	case workloadLocationSchemeFile:
+		if !isSandboxed() {
+			return nil, fmt.Errorf("attempted to execute agent-local workload artifact %s outside of sandbox ", req.Location.String())
+		}
+
 		path, _ := strings.CutPrefix(req.Location.String(), fmt.Sprintf("%s://", workloadLocationSchemeFile))
 
 		fi, err := os.Stat(path)

--- a/internal/node/controlapi.go
+++ b/internal/node/controlapi.go
@@ -418,6 +418,7 @@ func (api *ApiListener) handleDeploy(ctx context.Context, span trace.Span, m *na
 		respondFail(controlapi.RunResponseType, m, "Could not deploy workload, agent pool did not initialize properly")
 		return
 	}
+
 	workloadName := request.DecodedClaims.Subject
 	span.SetAttributes(attribute.String("workload_name", workloadName))
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -403,9 +403,15 @@ func (n *Node) handleAutostarts() {
 			continue
 		}
 
-		agentDeployRequest := agentDeployRequestFromControlDeployRequest(request, autostart.Namespace, numBytes, *workloadHash)
+		var hash string
+		if workloadHash != nil {
+			hash = *workloadHash // HACK!!! for agent-local workloads, this should be read from the release manifest
+		}
+
+		agentDeployRequest := agentDeployRequestFromControlDeployRequest(request, autostart.Namespace, numBytes, hash)
+
 		agentDeployRequest.TotalBytes = int64(numBytes)
-		agentDeployRequest.Hash = *workloadHash
+		agentDeployRequest.Hash = hash
 
 		err = n.manager.DeployWorkload(agentClient, agentDeployRequest)
 		if err != nil {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -350,6 +350,8 @@ func (n *Node) handleAutostarts() {
 					n.shutdown()
 					return
 				}
+
+				time.Sleep(time.Millisecond * 50)
 			}
 		}
 

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -156,7 +156,7 @@ func (w *WorkloadManager) Start() {
 }
 
 func (m *WorkloadManager) CacheWorkload(workloadID string, request *controlapi.DeployRequest) (uint64, *string, error) {
-	switch request.Location.Scheme {
+	switch strings.ToLower(request.Location.Scheme) {
 	case controlapi.WorkloadLocationSchemeFile:
 		if m.config.NoSandbox {
 			return 0, nil, fmt.Errorf("Attempted to deploy agent-local workload artifact outside of sandbox")


### PR DESCRIPTION
This PR allows the workload deploy `location` to be specified using a `file://` or `nats://` URL scheme.

File-based deploy locations are treated as "agent-local" workload deploy requests, meaning the agent will attempt to resolve the named file as an executable installed on its rootfs. File-based workload deploy requests can only be executed in sandbox mode.