### PR TITLE
Fix stability of workload deployment and process accounting

### DIFF
--- a/.github/workflows/ltb.yml
+++ b/.github/workflows/ltb.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
     - 
       uses: actions/checkout@v4

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,13 +14,15 @@ tasks:
     sources:
       - "*.go"
     cmds:
-#      - go build -tags netgo -ldflags '-extldflags "-static"'
-      - go build
+      - go build -tags netgo -ldflags '-extldflags "-static"'
 
   clean:
     cmds:
       - rm -f nex/nex
       - rm -f rootfs.ext4.gz
+      - sudo killall -9 nex || true
+      - sudo killall -9 nex-agent || true
+      - sudo killall -9 firecracker || true
       - sudo rm -rf /opt/cni/bin/*
       - sudo rm -rf /var/lib/cni/*
       - sudo rm -rf /etc/cni/conf.d/*
@@ -33,6 +35,8 @@ tasks:
       - sudo rm -rf /tmp/*-spec-nex-wd
       - sudo rm -rf /tmp/rootfs-*.ext4
       - sudo rm -rf /tmp/*-rootfs.ext4
+      - sudo rm -rf /tmp/workload-*
+      - sudo rm -rf /tmp/*-non-existent-nex-resource-dir
 
   nex:
     dir: nex

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -203,23 +203,8 @@ func (a *Agent) deleteExecutableArtifact() error {
 	fileName := fmt.Sprintf("workload-%s", *a.md.VmID)
 	tempFile := path.Join(os.TempDir(), fileName)
 
-	// if strings.EqualFold(runtime.GOOS, "windows") && req.WorkloadType == controlapi.NexWorkloadNative {
-	// 	tempFile = fmt.Sprintf("%s.exe", tempFile)
-	// }
-
 	_ = os.Remove(tempFile)
-	// if err != nil {
-	// 	msg := fmt.Sprintf("Failed to delete workload artifact from temp dir: %s", err)
-	// 	a.LogError(msg)
-	// 	return errors.New(msg)
-	// }
-
 	_ = a.cacheBucket.Delete(*a.md.VmID)
-	// if err != nil {
-	// 	msg := fmt.Sprintf("Failed to delete workload artifact from configured cache bucket: %s", err)
-	// 	a.LogError(msg)
-	// 	return errors.New(msg)
-	// }
 
 	return nil
 }

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -257,6 +257,7 @@ func (v *V8) Validate() error {
 	}
 
 	v.initUtils()
+	_ = os.Remove(v.tmpFilename)
 
 	return nil
 }

--- a/agent/providers/lib/wasm.go
+++ b/agent/providers/lib/wasm.go
@@ -24,6 +24,7 @@ type Wasm struct {
 	runtime       wazero.Runtime
 	runtimeConfig wazero.ModuleConfig
 	module        wazero.CompiledModule
+	tmpFile       string
 
 	fail chan bool
 	run  chan bool
@@ -92,7 +93,7 @@ func (e *Wasm) Execute(ctx context.Context, payload []byte) ([]byte, error) {
 }
 
 func (e *Wasm) Undeploy() error {
-	// We shouldn't have to do anything here since the wasm "owns" no resources
+	_ = os.Remove(e.tmpFile)
 	return nil
 }
 
@@ -157,7 +158,8 @@ func InitNexExecutionProviderWasm(params *agentapi.ExecutionProviderParams) (*Wa
 		run:  params.Run,
 		exit: params.Exit,
 
-		nc: params.NATSConn,
+		nc:      params.NATSConn,
+		tmpFile: *params.TmpFilename,
 	}, nil
 }
 

--- a/control-api/client.go
+++ b/control-api/client.go
@@ -79,6 +79,7 @@ func (api *Client) StartWorkload(request *DeployRequest) (*RunResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &response, nil
 }
 
@@ -394,6 +395,7 @@ func handleLogEntry(api *Client, ch chan EmittedLog) func(m *nats.Msg) {
 func (api *Client) performRequest(subject string, raw interface{}) ([]byte, error) {
 	var bytes []byte
 	var err error
+
 	if raw == nil {
 		bytes = []byte{}
 	} else {
@@ -407,13 +409,16 @@ func (api *Client) performRequest(subject string, raw interface{}) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
+
 	env, err := extractEnvelope(resp.Data)
 	if err != nil {
 		return nil, err
 	}
+
 	if env.Error != nil {
 		return nil, fmt.Errorf("%v", env.Error)
 	}
+
 	return json.Marshal(env.Data)
 }
 
@@ -421,10 +426,12 @@ func extractEnvelope(data []byte) (*Envelope, error) {
 	if len(data) == 0 {
 		return nil, errors.New("no data for envelope")
 	}
+
 	var env Envelope
 	err := json.Unmarshal(data, &env)
 	if err != nil {
 		return nil, err
 	}
+
 	return &env, nil
 }

--- a/control-api/types.go
+++ b/control-api/types.go
@@ -120,9 +120,10 @@ type MachineSummary struct { // FIXME-- rename to workload summary?
 type WorkloadSummary struct {
 	Name         string      `json:"name"`
 	Description  string      `json:"description,omitempty"`
-	Runtime      string      `json:"runtime"`
-	WorkloadType NexWorkload `json:"type"`
 	Hash         string      `json:"hash"`
+	Runtime      string      `json:"runtime"`
+	Uptime       string      `json:"uptime"`
+	WorkloadType NexWorkload `json:"type"`
 }
 
 type Envelope struct {

--- a/control-api/types.go
+++ b/control-api/types.go
@@ -99,21 +99,22 @@ type MemoryStat struct {
 }
 
 type InfoResponse struct {
-	Version                string            `json:"version"`
-	Uptime                 string            `json:"uptime"`
-	PublicXKey             string            `json:"public_xkey"`
-	Tags                   map[string]string `json:"tags,omitempty"`
+	AvailableAgents        int               `json:"available_agents"`
+	Machines               []MachineSummary  `json:"machines"` // FIXME-- rename to workloads?
 	Memory                 *MemoryStat       `json:"memory,omitempty"`
-	Machines               []MachineSummary  `json:"machines"`
+	PublicXKey             string            `json:"public_xkey"`
 	SupportedWorkloadTypes []NexWorkload     `json:"supported_workload_types,omitempty"`
+	Tags                   map[string]string `json:"tags,omitempty"`
+	Uptime                 string            `json:"uptime"`
+	Version                string            `json:"version"`
 }
 
-type MachineSummary struct {
+type MachineSummary struct { // FIXME-- rename to workload summary?
 	Id        string          `json:"id"`
 	Healthy   bool            `json:"healthy"`
 	Uptime    string          `json:"uptime"`
 	Namespace string          `json:"namespace,omitempty"`
-	Workload  WorkloadSummary `json:"workload,omitempty"`
+	Workload  WorkloadSummary `json:"workload,omitempty"` // FIXME-- rename to deploy request?
 }
 
 type WorkloadSummary struct {

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -257,12 +257,10 @@ func (a *AgentClient) IsSelected() bool {
 }
 
 func (a *AgentClient) MarkSelected() {
-	// make sure not to call this anywhere other than SelectRandomAgent()!!!
 	a.selected = true
 }
 
 func (a *AgentClient) MarkUnselected() {
-	// make sure not to call this anywhere other than SelectRandomAgent()!!!
 	a.selected = false
 }
 

--- a/internal/models/cli.go
+++ b/internal/models/cli.go
@@ -192,6 +192,10 @@ func GenerateConnectionFromOpts(opts *Options, logger *slog.Logger) (*nats.Conn,
 	}
 
 	conn, err := nats.Connect(opts.Servers, natsOpts...)
+	if err != nil {
+		return nil, err
+	}
+
 	logger.Debug("Connected to NATS server",
 		slog.String("server", conn.ConnectedUrlRedacted()),
 		slog.String("name", opts.ConnectionName),

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -29,7 +29,7 @@ var (
 	RequiredTriggerSubjectDenyList = []string{"$SYS.>", "$JS.>", "$NEX.>"}
 	DefaultWorkloadTypes           = []controlapi.NexWorkload{controlapi.NexWorkloadNative}
 
-	DefaultBinPath    = filepath.SplitList(os.Getenv("PATH"))
+	DefaultBinPath    = buildDefaultBinPath()
 	DefaultCNIBinPath = filepath.SplitList(os.Getenv("PATH"))
 )
 
@@ -217,4 +217,20 @@ func DefaultNodeConfiguration() NodeConfiguration {
 	}
 
 	return config
+}
+
+func buildDefaultBinPath() []string {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.SplitList(os.Getenv("PATH"))
+	}
+
+	defaultBinPath := filepath.Join(homedir, ".nex", "bin")
+	_ = os.MkdirAll(defaultBinPath, 0755)
+
+	path := make([]string, 0)
+	path = append(path, defaultBinPath)
+	path = append(path, filepath.SplitList(os.Getenv("PATH"))...)
+
+	return path
 }

--- a/internal/node/controlapi.go
+++ b/internal/node/controlapi.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nats-io/nkeys"
 	"github.com/pkg/errors"
 	controlapi "github.com/synadia-io/nex/control-api"
+	agentapi "github.com/synadia-io/nex/internal/agent-api"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -330,16 +331,38 @@ func (api *ApiListener) handleDeploy(ctx context.Context, span trace.Span, m *na
 		return
 	}
 
-	agentClient, err := api.mgr.SelectRandomAgent()
-	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-		api.log.Error("Failed to get agent client from pool", slog.Any("err", err))
-		respondFail(controlapi.RunResponseType, m, fmt.Sprintf("Failed to get agent client from pool: %s", err))
-		return
+	var agentClient *agentapi.AgentClient
+
+	retry := 0
+	for agentClient == nil {
+		agentClient, err = api.mgr.SelectRandomAgent()
+		if err != nil {
+			api.log.Warn("Failed to resolve agent for attempted deploy",
+				slog.String("error", err.Error()),
+			)
+
+			retry += 1
+			if retry > agentPoolRetryMax-1 {
+				api.log.Error("Exceeded warm agent retrieval retry count during attempted deploy",
+					slog.Int("allowed_retries", agentPoolRetryMax),
+				)
+
+				span.SetStatus(codes.Error, err.Error())
+				api.log.Error("Failed to get agent client from pool", slog.Any("err", err))
+				respondFail(controlapi.RunResponseType, m, fmt.Sprintf("Failed to get agent client from pool: %s", err))
+				return
+			}
+
+			time.Sleep(time.Millisecond * 100)
+		}
 	}
 
 	workloadID := agentClient.ID()
 	span.SetAttributes(attribute.String("workload_id", workloadID))
+
+	api.log.Debug("Resolved warm agent for attempted deploy",
+		slog.String("workload_id", workloadID),
+	)
 
 	span.AddEvent("Started workload download")
 	numBytes, workloadHash, err := api.mgr.CacheWorkload(workloadID, &request)
@@ -350,11 +373,13 @@ func (api *ApiListener) handleDeploy(ctx context.Context, span trace.Span, m *na
 		return
 	}
 	span.AddEvent("Completed workload download")
+
 	if api.exceedsMaxWorkloadSize(numBytes) {
 		span.SetStatus(codes.Error, "Workload file size is too big")
 		respondFail(controlapi.RunResponseType, m, "Workload file size would exceed node limitations")
 		return
 	}
+
 	if api.exceedsPerNodeWorkloadSizeMax(numBytes) {
 		span.SetStatus(codes.Error, "Workload file size exceeds node limitations")
 		respondFail(controlapi.RunResponseType, m, "Workload file size would exceed node total limitations")
@@ -367,6 +392,7 @@ func (api *ApiListener) handleDeploy(ctx context.Context, span trace.Span, m *na
 		Info("Submitting workload to agent",
 			slog.String("namespace", namespace),
 			slog.String("workload", *agentDeployRequest.WorkloadName),
+			slog.String("workload_id", workloadID),
 			slog.Uint64("workload_size", numBytes),
 			slog.String("workload_sha256", *workloadHash),
 			slog.String("type", string(request.WorkloadType)),
@@ -596,25 +622,46 @@ func (api *ApiListener) handleInfo(ctx context.Context, span trace.Span, m *nats
 		return
 	}
 
-	machines, err := api.mgr.RunningWorkloads()
+	workloads, err := api.mgr.RunningWorkloads()
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		api.log.Error("Failed to query running machines", slog.Any("error", err))
-		respondFail(controlapi.PingResponseType, m, "Failed to query running machines on node")
+		api.log.Error("Failed to query running workloads", slog.Any("error", err))
+		respondFail(controlapi.InfoResponseType, m, "Failed to query running workloads on node")
 		return
 	}
 
-	pubX, _ := api.xk.PublicKey()
-	now := time.Now().UTC()
-	stats, _ := ReadMemoryStats()
+	namespaceWorkloads := make([]controlapi.MachineSummary, 0)
+	for _, w := range workloads {
+		if strings.EqualFold(w.Namespace, namespace) {
+			namespaceWorkloads = append(namespaceWorkloads, w)
+		}
+	}
+
+	pubX, err := api.xk.PublicKey()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		api.log.Error("Failed to query running workloads", slog.Any("error", err))
+		respondFail(controlapi.InfoResponseType, m, "Failed to query running workloads on node")
+		return
+	}
+
+	stats, err := ReadMemoryStats()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		api.log.Error("Failed to query running workloads", slog.Any("error", err))
+		respondFail(controlapi.InfoResponseType, m, "Failed to query running workloads on node")
+		return
+	}
+
 	res := controlapi.NewEnvelope(controlapi.InfoResponseType, controlapi.InfoResponse{
-		Version:                VERSION,
-		PublicXKey:             pubX,
-		Uptime:                 myUptime(now.Sub(api.start)),
-		Tags:                   api.node.config.Tags,
-		SupportedWorkloadTypes: api.node.config.WorkloadTypes,
-		Machines:               summarizeMachines(machines, namespace), // filters by namespace
+		AvailableAgents:        len(api.mgr.pendingAgents),
+		Machines:               namespaceWorkloads,
 		Memory:                 stats,
+		PublicXKey:             pubX,
+		SupportedWorkloadTypes: api.node.config.WorkloadTypes,
+		Tags:                   api.node.config.Tags,
+		Uptime:                 myUptime(time.Now().UTC().Sub(api.start)),
+		Version:                VERSION,
 	}, nil)
 
 	raw, err := json.Marshal(res)
@@ -640,16 +687,6 @@ func (api *ApiListener) exceedsMaxWorkloadSize(bytes uint64) bool {
 func (api *ApiListener) exceedsPerNodeWorkloadSizeMax(bytes uint64) bool {
 	return api.node.config.NodeLimits.MaxTotalBytes > 0 &&
 		bytes+api.mgr.TotalRunningWorkloadBytes() > uint64(api.node.config.NodeLimits.MaxTotalBytes)
-}
-
-func summarizeMachines(workloads []controlapi.MachineSummary, namespace string) []controlapi.MachineSummary {
-	machines := make([]controlapi.MachineSummary, 0)
-	for _, w := range workloads {
-		if strings.EqualFold(w.Namespace, namespace) {
-			machines = append(machines, w)
-		}
-	}
-	return machines
 }
 
 func summarizeMachinesForPing(workloads []controlapi.MachineSummary, namespace string, workloadId string) []controlapi.WorkloadPingMachineSummary {

--- a/internal/node/init.go
+++ b/internal/node/init.go
@@ -67,9 +67,9 @@ func CmdPreflight(opts *nexmodels.Options, nodeopts *nexmodels.NodeOptions, ctx 
 	config.ForceDepInstall = nodeopts.ForceDepInstall
 	config.CNI.Nameservers = nodeopts.CniNS
 	config.PreflightCheck = nodeopts.PreflightCheck
+	config.PreflightInstallVersion = nodeopts.PreflightInstallVersion
 	config.PreflightVerify = nodeopts.PreflightVerify
 	config.PreflightVerbose = nodeopts.PreflightVerbose
-	config.PreflightInstallVersion = nodeopts.PreflightInstallVersion
 	config.PreflightYes = nodeopts.PreflightYes
 
 	err = preflight.Preflight(ctx, config, log)

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -2,6 +2,7 @@ package internalnats
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"text/template"
 )
@@ -89,6 +90,6 @@ func GenerateTemplate(log *slog.Logger, config internalServerData) ([]byte, erro
 	}
 
 	// -8 is equivalent to TRACE-ish level
-	log.Debug("generated NATS config", slog.String("config", wr.String()))
+	log.Log(context.Background(), -8, "generated NATS config", slog.String("config", wr.String()))
 	return wr.Bytes(), nil
 }

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -2,7 +2,6 @@ package internalnats
 
 import (
 	"bytes"
-	"context"
 	"log/slog"
 	"text/template"
 )
@@ -29,7 +28,6 @@ type credentials struct {
 const (
 	configTemplate = `
 jetstream: true
-
 accounts: {
 	nexhost: {
 		jetstream: true		
@@ -76,7 +74,7 @@ accounts: {
 	{{ end }}
 }
 no_sys_acc: true
-debug: false
+debug: true
 trace: false
 `
 )
@@ -91,6 +89,6 @@ func GenerateTemplate(log *slog.Logger, config internalServerData) ([]byte, erro
 	}
 
 	// -8 is equivalent to TRACE-ish level
-	log.Log(context.Background(), -8, "generated NATS config", slog.String("config", wr.String()))
+	log.Debug("generated NATS config", slog.String("config", wr.String()))
 	return wr.Bytes(), nil
 }

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"log/slog"
 	"text/template"
+
+	"github.com/nats-io/nats.go"
 )
 
 type internalServerData struct {
 	Credentials       map[string]*credentials
+	Connections       map[string]*nats.Conn
 	NexHostUserPublic string
 	NexHostUserSeed   string
 }

--- a/internal/node/internal-nats/config_template.go
+++ b/internal/node/internal-nats/config_template.go
@@ -80,7 +80,7 @@ trace: false
 `
 )
 
-func GenerateTemplate(log *slog.Logger, config internalServerData) ([]byte, error) {
+func GenerateTemplate(log *slog.Logger, config *internalServerData) ([]byte, error) {
 	var wr bytes.Buffer
 
 	t := template.Must(template.New("natsconfig").Parse(configTemplate))

--- a/internal/node/internal-nats/config_template_test.go
+++ b/internal/node/internal-nats/config_template_test.go
@@ -43,7 +43,7 @@ func TestTemplateGenerator(t *testing.T) {
 		}
 	}
 
-	bytes, err := GenerateTemplate(slog.Default(), data)
+	bytes, err := GenerateTemplate(slog.Default(), &data)
 	if err != nil {
 		t.Fatalf("failed to render template: %s", err)
 	}

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -150,7 +150,7 @@ func (s *InternalNatsServer) CreateCredentials(id string) (nkeys.KeyPair, error)
 		return nil, err
 	}
 
-	nc, err := s.ConnectionWithCredentials(creds)
+	nc, err := s.ConnectionWithID(id)
 	if err != nil {
 		s.log.Error("Failed to obtain connection for given credentials", slog.Any("error", err))
 		return nil, err

--- a/internal/node/internal-nats/internal_nats_server.go
+++ b/internal/node/internal-nats/internal_nats_server.go
@@ -172,6 +172,10 @@ func (s *InternalNatsServer) DestroyCredentials(id string) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	if nc, ok := s.serverConfigData.Connections[id]; ok {
+		_ = nc.Drain()
+	}
+
 	delete(s.serverConfigData.Credentials, id)
 	delete(s.serverConfigData.Connections, id)
 

--- a/internal/node/internal-nats/internal_nats_server_test.go
+++ b/internal/node/internal-nats/internal_nats_server_test.go
@@ -97,7 +97,7 @@ func TestInternalNatsServerFileCache(t *testing.T) {
 	userCn, _ := server.ConnectionWithCredentials(ud)
 	js, _ := jetstream.New(userCn)
 	bucket, _ := js.ObjectStore(ctx, workloadCacheBucketName)
-	workload, err := bucket.GetBytes(ctx, workloadCacheFileKey)
+	workload, err := bucket.GetBytes(ctx, workloadId)
 	if err != nil {
 		t.Fatalf("Should have queried the workload bytes, but got error instead: %s", err)
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -372,6 +372,7 @@ func (n *Node) handleAutostarts() {
 			n.log.Error("Failed to create deployment request for autostart workload",
 				slog.Any("error", err),
 			)
+			agentClient.MarkUnselected()
 			continue
 		}
 
@@ -384,6 +385,7 @@ func (n *Node) handleAutostarts() {
 			n.log.Error("Failed to validate autostart deployment request",
 				slog.Any("error", err),
 			)
+			agentClient.MarkUnselected()
 			continue
 		}
 
@@ -396,6 +398,7 @@ func (n *Node) handleAutostarts() {
 				slog.String("namespace", autostart.Namespace),
 				slog.String("url", autostart.Location),
 			)
+			agentClient.MarkUnselected()
 			continue
 		}
 
@@ -410,6 +413,7 @@ func (n *Node) handleAutostarts() {
 				slog.String("name", autostart.Name),
 				slog.String("namespace", autostart.Namespace),
 			)
+			agentClient.MarkUnselected()
 			continue
 		}
 

--- a/internal/node/preflight/init.go
+++ b/internal/node/preflight/init.go
@@ -31,11 +31,12 @@ var (
 				fmt.Printf("error making http request: %s\n", err)
 				return ""
 			}
+			defer res.Body.Close()
+
 			if res.StatusCode != 200 {
 				fmt.Printf("error fetching latest version from github: %s\n", res.Status)
 				return ""
 			}
-			defer res.Body.Close()
 
 			b, err := io.ReadAll(res.Body)
 			if err != nil {

--- a/internal/node/preflight/preflight.go
+++ b/internal/node/preflight/preflight.go
@@ -45,7 +45,10 @@ func Preflight(ctx context.Context, config *models.NodeConfiguration, logger *sl
 		nexVer = config.PreflightInstallVersion
 	}
 
-	logger.Debug("using nex version", slog.String("version", nexVer))
+	logger.Debug("Using nex preflight install version",
+		slog.String("version", nexVer),
+		slog.String("bin_path", strings.Join(config.BinPath, string(os.PathListSeparator))),
+	)
 
 	required, err := preflightInit(nexVer, config, logger)
 	if errors.Is(err, ErrNoSandboxRequired) {
@@ -63,6 +66,7 @@ func Preflight(ctx context.Context, config *models.NodeConfiguration, logger *sl
 			if r.satisfied {
 				continue
 			}
+
 			if r.nosandbox == config.NoSandbox {
 				if di == 0 && config.PreflightVerbose {
 					sb.WriteString(fmt.Sprintf("Validating - %s\n", magenta(r.description)))
@@ -83,6 +87,7 @@ func Preflight(ctx context.Context, config *models.NodeConfiguration, logger *sl
 				r.satisfied = true
 			}
 		}
+
 		if !r.satisfied {
 			sb.WriteString(fmt.Sprintf("⛔ Dependency Missing - %s\n", cyan(r.description)))
 		}

--- a/internal/node/processmanager/firecracker_procman.go
+++ b/internal/node/processmanager/firecracker_procman.go
@@ -239,15 +239,6 @@ func (f *FirecrackerProcessManager) StopProcess(workloadID string) error {
 	return nil
 }
 
-// func (f *FirecrackerProcessManager) Lookup(workloadID string) (*agentapi.DeployRequest, error) {
-// 	if request, ok := f.deployRequests[workloadID]; ok {
-// 		return request, nil
-// 	}
-
-// 	// Per contract, a non-prepared workload returns nil, not error
-// 	return nil, nil
-// }
-
 func (f *FirecrackerProcessManager) resetCNI() error {
 	f.log.Info("Resetting network")
 

--- a/internal/node/processmanager/process_mgr.go
+++ b/internal/node/processmanager/process_mgr.go
@@ -35,9 +35,6 @@ type ProcessManager interface {
 	// Returns a list of agent processes in an implementation-agnostic format
 	ListProcesses() ([]ProcessInfo, error)
 
-	// Lookup a deploy request by id. Returns nil when attempting to lookup an "unprepared" workload
-	Lookup(id string) (*agentapi.DeployRequest, error)
-
 	// Associate a deploy request with the given workload id, and perform any
 	// just in time initialization of resources if necessary
 	PrepareWorkload(id string, request *agentapi.DeployRequest) error

--- a/internal/node/processmanager/running_vm.go
+++ b/internal/node/processmanager/running_vm.go
@@ -89,7 +89,6 @@ func (vm *runningFirecracker) shutdown() {
 
 // Create a VMM with a given set of options and start the VM
 func createAndStartVM(ctx context.Context, vmmID string, config *nexmodels.NodeConfiguration, log *slog.Logger) (*runningFirecracker, error) {
-
 	fcCfg, err := generateFirecrackerConfig(vmmID, config)
 	if err != nil {
 		log.Error("Failed to generate firecracker configuration", slog.Any("config", config))

--- a/internal/node/processmanager/spawn_procman.go
+++ b/internal/node/processmanager/spawn_procman.go
@@ -212,17 +212,6 @@ func (s *SpawningProcessManager) StopProcess(workloadID string) error {
 	return nil
 }
 
-// Looks up an agent process. A non-existent agent process returns (nil, nil), not
-// an error
-// func (s *SpawningProcessManager) Lookup(workloadID string) (*agentapi.DeployRequest, error) {
-// 	if request, ok := s.deployRequests[workloadID]; ok {
-// 		return request, nil
-// 	}
-
-// 	// Per contract, a non-prepared workload returns nil, not error
-// 	return nil, nil
-// }
-
 // Checks if the process manager is stopping
 func (s *SpawningProcessManager) stopping() bool {
 	return (atomic.LoadUint32(&s.closing) > 0)

--- a/internal/node/processmanager/spawn_procman.go
+++ b/internal/node/processmanager/spawn_procman.go
@@ -32,9 +32,10 @@ type SpawningProcessManager struct {
 	stopMutexes map[string]*sync.Mutex
 	t           *observability.Telemetry
 
-	liveProcs map[string]*spawnedProcess
-	warmProcs chan *spawnedProcess
-	intNats   *internalnats.InternalNatsServer
+	allProcs  map[string]*spawnedProcess
+	poolProcs chan *spawnedProcess
+
+	natsint *internalnats.InternalNatsServer
 
 	delegate       ProcessDelegate
 	deployRequests map[string]*agentapi.DeployRequest
@@ -66,7 +67,7 @@ func NewSpawningProcessManager(
 	return &SpawningProcessManager{
 		config:  config,
 		ctx:     ctx,
-		intNats: intNats,
+		natsint: intNats,
 		log:     log,
 		mutex:   &sync.Mutex{},
 		t:       telemetry,
@@ -74,8 +75,8 @@ func NewSpawningProcessManager(
 		stopMutexes: make(map[string]*sync.Mutex),
 
 		deployRequests: make(map[string]*agentapi.DeployRequest),
-		liveProcs:      make(map[string]*spawnedProcess),
-		warmProcs:      make(chan *spawnedProcess, config.MachinePoolSize),
+		allProcs:       make(map[string]*spawnedProcess),
+		poolProcs:      make(chan *spawnedProcess, config.MachinePoolSize),
 	}, nil
 }
 
@@ -83,7 +84,7 @@ func NewSpawningProcessManager(
 func (s *SpawningProcessManager) ListProcesses() ([]ProcessInfo, error) {
 	pinfos := make([]ProcessInfo, 0)
 
-	for workloadID, proc := range s.liveProcs {
+	for workloadID, proc := range s.allProcs {
 		// Ignore pending "unprepared" processes that don't have workloads on them yet
 		if proc.deployRequest != nil {
 			pinfo := ProcessInfo{
@@ -113,7 +114,7 @@ func (s *SpawningProcessManager) PrepareWorkload(workloadID string, deployReques
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	proc := <-s.warmProcs
+	proc := <-s.poolProcs
 	if proc == nil {
 		return fmt.Errorf("could not prepare workload, no available agent process")
 	}
@@ -131,7 +132,7 @@ func (s *SpawningProcessManager) Stop() error {
 	if atomic.AddUint32(&s.closing, 1) == 1 {
 		s.log.Info("Spawning process manager stopping")
 
-		for workloadID := range s.liveProcs {
+		for workloadID := range s.allProcs {
 			err := s.StopProcess(workloadID)
 			if err != nil {
 				s.log.Warn("Failed to stop spawned agent process",
@@ -155,7 +156,7 @@ func (s *SpawningProcessManager) Start(delegate ProcessDelegate) error {
 		case <-s.ctx.Done():
 			return nil
 		default:
-			if len(s.warmProcs) == s.config.MachinePoolSize {
+			if len(s.poolProcs) == s.config.MachinePoolSize {
 				time.Sleep(runloopSleepInterval)
 				continue
 			}
@@ -167,7 +168,7 @@ func (s *SpawningProcessManager) Start(delegate ProcessDelegate) error {
 				continue
 			}
 
-			s.liveProcs[p.ID] = p
+			s.allProcs[p.ID] = p
 			s.stopMutexes[p.ID] = &sync.Mutex{}
 
 			go s.delegate.OnProcessStarted(p.ID)
@@ -175,7 +176,7 @@ func (s *SpawningProcessManager) Start(delegate ProcessDelegate) error {
 			s.log.Info("Adding new agent process to warm pool",
 				slog.String("workload_id", p.ID))
 
-			s.warmProcs <- p // If the pool is full, this line will block until a slot is available.
+			s.poolProcs <- p // If the pool is full, this line will block until a slot is available.
 		}
 	}
 
@@ -187,7 +188,7 @@ func (s *SpawningProcessManager) StopProcess(workloadID string) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	proc, exists := s.liveProcs[workloadID]
+	proc, exists := s.allProcs[workloadID]
 	if !exists {
 		return fmt.Errorf("failed to stop process %s. No such process", workloadID)
 	}
@@ -205,7 +206,7 @@ func (s *SpawningProcessManager) StopProcess(workloadID string) error {
 		return err
 	}
 
-	delete(s.liveProcs, workloadID)
+	delete(s.allProcs, workloadID)
 	delete(s.stopMutexes, workloadID)
 
 	return nil
@@ -213,14 +214,14 @@ func (s *SpawningProcessManager) StopProcess(workloadID string) error {
 
 // Looks up an agent process. A non-existent agent process returns (nil, nil), not
 // an error
-func (s *SpawningProcessManager) Lookup(workloadID string) (*agentapi.DeployRequest, error) {
-	if request, ok := s.deployRequests[workloadID]; ok {
-		return request, nil
-	}
+// func (s *SpawningProcessManager) Lookup(workloadID string) (*agentapi.DeployRequest, error) {
+// 	if request, ok := s.deployRequests[workloadID]; ok {
+// 		return request, nil
+// 	}
 
-	// Per contract, a non-prepared workload returns nil, not error
-	return nil, nil
-}
+// 	// Per contract, a non-prepared workload returns nil, not error
+// 	return nil, nil
+// }
 
 // Checks if the process manager is stopping
 func (s *SpawningProcessManager) stopping() bool {
@@ -232,7 +233,7 @@ func (s *SpawningProcessManager) spawn() (*spawnedProcess, error) {
 	id := xid.New()
 	workloadID := id.String()
 
-	kp, err := s.intNats.CreateCredentials(workloadID)
+	kp, err := s.natsint.CreateCredentials(workloadID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -322,10 +322,9 @@ func (w *WorkloadManager) RunningWorkloads() ([]controlapi.MachineSummary, error
 	for id, agentClient := range w.liveAgents {
 		deployRequest := agentClient.DeployRequest()
 
-		uptimeFriendly := "unknown"
-		runtimeFriendly := "unknown"
+		uptimeFriendly := myUptime(agentClient.UptimeMillis())
+		runtimeFriendly := "--"
 
-		uptimeFriendly = myUptime(agentClient.UptimeMillis())
 		if agentClient.WorkloadType() == controlapi.NexWorkloadV8 || agentClient.WorkloadType() == controlapi.NexWorkloadWasm {
 			nanoTime := fmt.Sprintf("%dns", agentClient.ExecTimeNanos())
 			rt, err := time.ParseDuration(nanoTime)

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -229,6 +229,7 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 
 	deployResponse, err := agentClient.DeployWorkload(request)
 	if err != nil {
+		delete(w.poolAgents, workloadID)
 		return fmt.Errorf("failed to submit request for workload deployment: %s", err)
 	}
 
@@ -685,10 +686,6 @@ func (w *WorkloadManager) SelectRandomAgent() (*agentapi.AgentClient, error) {
 	w.poolMutex.Lock()
 	defer w.poolMutex.Unlock()
 
-	if len(w.poolAgents) == 0 {
-		return nil, errors.New("no available agent client in pool")
-	}
-
 	// there might be a slightly faster version of this, but this effectively
 	// gives us a random pick among the map elements
 	for _, agentClient := range w.poolAgents {
@@ -700,7 +697,7 @@ func (w *WorkloadManager) SelectRandomAgent() (*agentapi.AgentClient, error) {
 		return agentClient, nil
 	}
 
-	return nil, nil
+	return nil, errors.New("no available agent client in pool")
 }
 
 func (w *WorkloadManager) TotalRunningWorkloadBytes() uint64 {

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -317,7 +317,7 @@ func (w *WorkloadManager) LookupWorkload(workloadID string) (*agentapi.DeployReq
 
 // Retrieve a list of deployed, running workloads
 func (w *WorkloadManager) RunningWorkloads() ([]controlapi.MachineSummary, error) {
-	summaries := make([]controlapi.MachineSummary, len(w.liveAgents))
+	summaries := make([]controlapi.MachineSummary, 0)
 
 	for id, agentClient := range w.liveAgents {
 		deployRequest := agentClient.DeployRequest()

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -469,7 +469,7 @@ func (w *WorkloadManager) OnProcessStarted(id string) {
 
 	clientConn, err := w.natsint.ConnectionWithID(id)
 	if err != nil {
-		w.log.Error("Failed to start agent client", slog.Any("err", err))
+		w.log.Error("Failed to resolve internal NATS connection for agent client", slog.Any("err", err))
 		return
 	}
 

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -59,11 +59,11 @@ type WorkloadManager struct {
 	procMan processmanager.ProcessManager
 
 	// Any agent client in this map is one that has successfully acknowledged a deployment
-	activeAgents map[string]*agentapi.AgentClient
+	liveAgents map[string]*agentapi.AgentClient
 
 	// Agent clients in this slice are attached to processes that have not yet received a deployment AND have
 	// successfully performed a handshake. Handshake failures are immediately removed
-	pendingAgents map[string]*agentapi.AgentClient
+	poolAgents map[string]*agentapi.AgentClient
 
 	handshakes       map[string]string
 	handshakeTimeout time.Duration
@@ -110,8 +110,8 @@ func NewWorkloadManager(
 		publicKey:        publicKey,
 		t:                telemetry,
 
-		pendingAgents: make(map[string]*agentapi.AgentClient),
-		activeAgents:  make(map[string]*agentapi.AgentClient),
+		poolAgents: make(map[string]*agentapi.AgentClient),
+		liveAgents: make(map[string]*agentapi.AgentClient),
 
 		stopMutex: make(map[string]*sync.Mutex),
 		subz:      make(map[string][]*nats.Subscription),
@@ -237,9 +237,9 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 			slog.String("workload_id", workloadID),
 		)
 
-		// move the client from active to pending
-		w.activeAgents[workloadID] = agentClient
-		delete(w.pendingAgents, workloadID)
+		// move the client from pool to pending
+		w.liveAgents[workloadID] = agentClient
+		delete(w.poolAgents, workloadID)
 
 		ncHostServices, err := w.createHostServicesConnection(request)
 		if err != nil {
@@ -260,11 +260,14 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 						slog.Any("error", err),
 						slog.String("url", request.TriggerConnection.NatsUrl),
 					)
+
 					_ = w.StopWorkload(workloadID, true)
 					return err
 				}
+
 				w.hostServices.server.AddHostServicesConnection(workloadID, hostservices.TriggerConnection, ncTrigger)
 			}
+
 			for _, tsub := range request.TriggerSubjects {
 				sub, err := ncTrigger.Subscribe(tsub, w.generateTriggerHandler(workloadID, tsub, request))
 				if err != nil {
@@ -304,57 +307,56 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 // Locates a given workload by its workload ID and returns the deployment request associated with it
 // Note that this means "pending" workloads are not considered by lookups
 func (w *WorkloadManager) LookupWorkload(workloadID string) (*agentapi.DeployRequest, error) {
-	return w.procMan.Lookup(workloadID)
+	if agentClient, ok := w.liveAgents[workloadID]; ok {
+		return agentClient.DeployRequest(), nil
+	}
+
+	return nil, fmt.Errorf("workload doesn't exist: %s", workloadID)
 }
 
 // Retrieve a list of deployed, running workloads
 func (w *WorkloadManager) RunningWorkloads() ([]controlapi.MachineSummary, error) {
-	procs, err := w.procMan.ListProcesses()
-	if err != nil {
-		return nil, err
-	}
+	summaries := make([]controlapi.MachineSummary, len(w.liveAgents))
 
-	summaries := make([]controlapi.MachineSummary, len(procs))
+	for id, agentClient := range w.liveAgents {
+		deployRequest := agentClient.DeployRequest()
 
-	for i, p := range procs {
 		uptimeFriendly := "unknown"
 		runtimeFriendly := "unknown"
-		agentClient, ok := w.activeAgents[p.ID]
-		if ok {
-			uptimeFriendly = myUptime(agentClient.UptimeMillis())
-			if p.DeployRequest.WorkloadType == controlapi.NexWorkloadV8 || p.DeployRequest.WorkloadType == controlapi.NexWorkloadWasm {
-				nanoTime := fmt.Sprintf("%dns", agentClient.ExecTimeNanos())
-				rt, err := time.ParseDuration(nanoTime)
-				if err == nil {
-					if rt.Nanoseconds() < 1000 {
-						runtimeFriendly = nanoTime
-					} else if rt.Milliseconds() < 1000 {
-						runtimeFriendly = fmt.Sprintf("%dms", rt.Milliseconds())
-					} else {
-						runtimeFriendly = myUptime(rt)
-					}
+
+		uptimeFriendly = myUptime(agentClient.UptimeMillis())
+		if agentClient.WorkloadType() == controlapi.NexWorkloadV8 || agentClient.WorkloadType() == controlapi.NexWorkloadWasm {
+			nanoTime := fmt.Sprintf("%dns", agentClient.ExecTimeNanos())
+			rt, err := time.ParseDuration(nanoTime)
+			if err == nil {
+				if rt.Nanoseconds() < 1000 {
+					runtimeFriendly = nanoTime
+				} else if rt.Milliseconds() < 1000 {
+					runtimeFriendly = fmt.Sprintf("%dms", rt.Milliseconds())
 				} else {
-					w.log.Warn("Failed to generate parsed time from nanos", slog.Any("error", err))
+					runtimeFriendly = myUptime(rt)
 				}
 			} else {
-				runtimeFriendly = uptimeFriendly
+				w.log.Warn("Failed to generate parsed time from nanos", slog.Any("error", err))
 			}
+		} else {
+			runtimeFriendly = uptimeFriendly
 		}
 
-		summaries[i] = controlapi.MachineSummary{
-			Id:        p.ID,
+		summaries = append(summaries, controlapi.MachineSummary{
+			Id:        id,
 			Healthy:   true, // FIXME!!!
 			Uptime:    uptimeFriendly,
-			Namespace: p.Namespace,
+			Namespace: *deployRequest.Namespace,
 			Workload: controlapi.WorkloadSummary{
-				Name:         p.Name,
-				Description:  *p.DeployRequest.Description,
-				Hash:         p.DeployRequest.Hash,
+				Name:         *deployRequest.WorkloadName,
+				Description:  *deployRequest.Description,
+				Hash:         deployRequest.Hash,
 				Runtime:      runtimeFriendly,
 				Uptime:       uptimeFriendly,
-				WorkloadType: p.DeployRequest.WorkloadType,
+				WorkloadType: deployRequest.WorkloadType,
 			},
-		}
+		})
 	}
 
 	return summaries, nil
@@ -366,11 +368,11 @@ func (w *WorkloadManager) Stop() error {
 	if atomic.AddUint32(&w.closing, 1) == 1 {
 		w.log.Info("Workload manager stopping")
 
-		for id := range w.pendingAgents {
-			_ = w.pendingAgents[id].Stop()
+		for id := range w.poolAgents {
+			_ = w.poolAgents[id].Stop()
 		}
 
-		for id := range w.activeAgents {
+		for id := range w.liveAgents {
 			err := w.StopWorkload(id, true)
 			if err != nil {
 				w.log.Warn("Failed to stop agent", slog.String("workload_id", id), slog.String("error", err.Error()))
@@ -396,16 +398,7 @@ func (w *WorkloadManager) Stop() error {
 
 // Stop a workload, optionally attempting a graceful undeploy prior to termination
 func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
-	defer func() {
-		delete(w.activeAgents, id)
-		delete(w.pendingAgents, id)
-		delete(w.stopMutex, id)
-		w.hostServices.server.RemoveHostServicesConnection(id)
-
-		_ = w.publishWorkloadStopped(id)
-	}()
-
-	deployRequest, err := w.procMan.Lookup(id)
+	deployRequest, err := w.LookupWorkload(id)
 	if err != nil {
 		w.log.Warn("request to undeploy workload failed", slog.String("workload_id", id), slog.String("error", err.Error()))
 		return err
@@ -436,7 +429,7 @@ func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
 	}
 
 	if deployRequest != nil && undeploy {
-		agentClient := w.activeAgents[id]
+		agentClient := w.liveAgents[id]
 		defer func() {
 			_ = agentClient.Drain()
 		}()
@@ -455,6 +448,13 @@ func (w *WorkloadManager) StopWorkload(id string, undeploy bool) error {
 		w.log.Warn("failed to stop workload process", slog.String("workload_id", id), slog.String("error", err.Error()))
 		return err
 	}
+
+	delete(w.liveAgents, id)
+	delete(w.poolAgents, id)
+	delete(w.stopMutex, id)
+	w.hostServices.server.RemoveHostServicesConnection(id)
+
+	_ = w.publishWorkloadStopped(id)
 
 	return nil
 }
@@ -491,7 +491,7 @@ func (w *WorkloadManager) OnProcessStarted(id string) {
 		return
 	}
 
-	w.pendingAgents[id] = agentClient
+	w.poolAgents[id] = agentClient
 	w.stopMutex[id] = &sync.Mutex{}
 }
 
@@ -500,7 +500,7 @@ func (w *WorkloadManager) agentHandshakeTimedOut(id string) {
 	defer w.poolMutex.Unlock()
 
 	w.log.Error("Did not receive NATS handshake from agent within timeout.", slog.String("workload_id", id))
-	delete(w.pendingAgents, id)
+	delete(w.poolAgents, id)
 
 	if len(w.handshakes) == 0 {
 		w.log.Error("First handshake failed, shutting down to avoid inconsistent behavior")
@@ -520,7 +520,7 @@ func (w *WorkloadManager) agentContactLost(workloadID string) {
 
 // Generate a NATS subscriber function that is used to trigger function-type workloads
 func (w *WorkloadManager) generateTriggerHandler(workloadID string, tsub string, request *agentapi.DeployRequest) func(msg *nats.Msg) {
-	agentClient, ok := w.activeAgents[workloadID]
+	agentClient, ok := w.liveAgents[workloadID]
 	if !ok {
 		w.log.Error("Attempted to generate trigger handler for non-existent agent client")
 		return nil
@@ -685,14 +685,19 @@ func (w *WorkloadManager) SelectRandomAgent() (*agentapi.AgentClient, error) {
 	w.poolMutex.Lock()
 	defer w.poolMutex.Unlock()
 
-	if len(w.pendingAgents) == 0 {
+	if len(w.poolAgents) == 0 {
 		return nil, errors.New("no available agent client in pool")
 	}
 
 	// there might be a slightly faster version of this, but this effectively
 	// gives us a random pick among the map elements
-	for _, v := range w.pendingAgents {
-		return v, nil
+	for _, agentClient := range w.poolAgents {
+		if agentClient.IsSelected() {
+			continue
+		}
+
+		agentClient.MarkSelected()
+		return agentClient, nil
 	}
 
 	return nil, nil
@@ -700,7 +705,7 @@ func (w *WorkloadManager) SelectRandomAgent() (*agentapi.AgentClient, error) {
 
 func (w *WorkloadManager) TotalRunningWorkloadBytes() uint64 {
 	total := uint64(0)
-	for _, c := range w.activeAgents {
+	for _, c := range w.liveAgents {
 		total += c.WorkloadBytes()
 	}
 

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -233,6 +233,10 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 	}
 
 	if deployResponse.Accepted {
+		w.log.Debug("Workload manager deploy attempt accepted",
+			slog.String("workload_id", workloadID),
+		)
+
 		// move the client from active to pending
 		w.activeAgents[workloadID] = agentClient
 		delete(w.pendingAgents, workloadID)
@@ -345,9 +349,10 @@ func (w *WorkloadManager) RunningWorkloads() ([]controlapi.MachineSummary, error
 			Workload: controlapi.WorkloadSummary{
 				Name:         p.Name,
 				Description:  *p.DeployRequest.Description,
-				Runtime:      runtimeFriendly,
-				WorkloadType: p.DeployRequest.WorkloadType,
 				Hash:         p.DeployRequest.Hash,
+				Runtime:      runtimeFriendly,
+				Uptime:       uptimeFriendly,
+				WorkloadType: p.DeployRequest.WorkloadType,
 			},
 		}
 	}

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -339,8 +339,6 @@ func (w *WorkloadManager) RunningWorkloads() ([]controlapi.MachineSummary, error
 			} else {
 				w.log.Warn("Failed to generate parsed time from nanos", slog.Any("error", err))
 			}
-		} else {
-			runtimeFriendly = uptimeFriendly
 		}
 
 		summaries = append(summaries, controlapi.MachineSummary{

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -467,7 +467,7 @@ func (w *WorkloadManager) OnProcessStarted(id string) {
 
 	w.log.Debug("Process started", slog.String("workload_id", id))
 
-	clientConn, err := w.natsint.ConnectionWithID(id)
+	clientConn, err := w.natsint.ConnectionByID(id)
 	if err != nil {
 		w.log.Error("Failed to resolve internal NATS connection for agent client", slog.Any("err", err))
 		return

--- a/internal/node/workload_mgr_events.go
+++ b/internal/node/workload_mgr_events.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (w *WorkloadManager) agentEvent(agentId string, evt cloudevents.Event) {
-	deployRequest, _ := w.procMan.Lookup(agentId)
+	deployRequest, _ := w.LookupWorkload(agentId)
 	if deployRequest == nil {
 		// got an event from a process that doesn't yet have a workload (deployment request) associated
 		// with it
@@ -90,7 +90,7 @@ func (w *WorkloadManager) agentEvent(agentId string, evt cloudevents.Event) {
 }
 
 func (w *WorkloadManager) agentLog(workloadId string, entry agentapi.LogEntry) {
-	deployRequest, _ := w.procMan.Lookup(workloadId)
+	deployRequest, _ := w.LookupWorkload(workloadId)
 	if deployRequest == nil {
 		// we got a log from a process that has not yet received a deployment, so it doesn't have a
 		// workload name or namespace
@@ -154,7 +154,7 @@ func (w *WorkloadManager) publishFunctionExecFailed(workloadId string, workloadN
 }
 
 func (w *WorkloadManager) publishFunctionExecSucceeded(workloadId string, tsub string, elapsedNanos int64) error {
-	deployRequest, err := w.procMan.Lookup(workloadId)
+	deployRequest, err := w.LookupWorkload(workloadId)
 	if err != nil {
 		w.log.Error("Failed to look up workload", slog.String("workload_id", workloadId), slog.Any("error", err))
 		return errors.New("function exec succeeded event was not published")
@@ -208,7 +208,7 @@ func (w *WorkloadManager) publishFunctionExecSucceeded(workloadId string, tsub s
 
 // publishWorkloadStopped writes a workload stopped event for the provided workload
 func (w *WorkloadManager) publishWorkloadStopped(workloadId string) error {
-	deployRequest, err := w.procMan.Lookup(workloadId)
+	deployRequest, err := w.LookupWorkload(workloadId)
 	if err != nil {
 		w.log.Error("Failed to look up workload", slog.String("workload_id", workloadId), slog.Any("error", err))
 		return errors.New("workload stopped event was not published")

--- a/nex/nodes.go
+++ b/nex/nodes.go
@@ -96,6 +96,7 @@ func renderNodeInfo(info *controlapi.InfoResponse, id string, full bool) {
 	cols.AddRowf("Xkey", info.PublicXKey)
 	cols.AddRow("Version", info.Version)
 	cols.AddRow("Uptime", info.Uptime)
+	cols.AddRow("Available Agents", info.AvailableAgents)
 
 	taglist := make([]string, 0)
 	for k, v := range info.Tags {

--- a/nex/nodes.go
+++ b/nex/nodes.go
@@ -139,7 +139,7 @@ func renderNodeInfo(info *controlapi.InfoResponse, id string, full bool) {
 
 		t.SetTitle("Workloads")
 		t.Style().Title.Align = text.AlignCenter
-		t.AppendHeader(table.Row{"", "ID", "Type", "Name", "Runtime"})
+		t.AppendHeader(table.Row{"", "ID", "Type", "Name", "Uptime", "Runtime"})
 
 		for _, m := range info.Machines {
 			health := func() string {
@@ -149,7 +149,7 @@ func renderNodeInfo(info *controlapi.InfoResponse, id string, full bool) {
 				return "🔴"
 			}()
 
-			t.AppendRow(table.Row{health, m.Id, m.Workload.WorkloadType, m.Workload.Name, m.Workload.Runtime})
+			t.AppendRow(table.Row{health, m.Id, m.Workload.WorkloadType, m.Workload.Name, m.Workload.Uptime, m.Workload.Runtime})
 		}
 
 		fmt.Println(t.Render())

--- a/spec/node_linux_test.go
+++ b/spec/node_linux_test.go
@@ -887,8 +887,8 @@ var _ = Describe("nex node", func() {
 			})
 		})
 	},
-		Entry("sandbox", true),     // sandbox mode
-		Entry("no-sandbox", false), // no-sandbox mode
+		Entry("sandbox", true), // sandbox mode
+		// Entry("no-sandbox", false), // no-sandbox mode
 	)
 })
 

--- a/spec/node_linux_test.go
+++ b/spec/node_linux_test.go
@@ -887,8 +887,8 @@ var _ = Describe("nex node", func() {
 			})
 		})
 	},
-		Entry("sandbox", true), // sandbox mode
-		// Entry("no-sandbox", false), // no-sandbox mode
+		Entry("sandbox", true),     // sandbox mode
+		Entry("no-sandbox", false), // no-sandbox mode
 	)
 })
 

--- a/spec/node_linux_test.go
+++ b/spec/node_linux_test.go
@@ -902,6 +902,7 @@ func awaitPendingAgents(nodeID string, count int, log *slog.Logger) {
 		info, _ := nodeClient.NodeInfo(nodeID)
 		if info != nil && info.AvailableAgents == count {
 			fmt.Printf("✅ Reached anticipated number of pending agents (%d) on node: %s", count, nodeID)
+			time.Sleep(time.Millisecond * 3000)
 			return
 		}
 

--- a/spec/spec_suite_test.go
+++ b/spec/spec_suite_test.go
@@ -78,7 +78,6 @@ func startNATS(storeDir string) (*server.Server, *nats.Conn, *int, error) {
 		Host:      "0.0.0.0",
 		Port:      -1,
 		JetStream: true,
-		NoLog:     true,
 		StoreDir:  storeDir,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR addresses the following instability issues:

- the internal NATS server had no mutex around the modification of the map that stores creds; in addition, we are now caching the first NATS connection created for the node to communicate with running agents

- MachineManager and ProcessManager implementations were not synchronized; MachineManager now returns data about agents and does not lookup agents/workloads using the ProcessManager interface

- deploying workloads using the controlapi package now implements logic to retry in the event no agent is available

- the spec harness was ill-equipped to handle testing multiple machines in the pool

- nex node info output has been updated to include more data