### PR TITLE
remove auto provision, simplify js hs api

### DIFF
--- a/agent/providers/lib/native.go
+++ b/agent/providers/lib/native.go
@@ -98,7 +98,7 @@ func (e *NativeExecutable) removeWorkload() {
 }
 
 func (e *NativeExecutable) Execute(ctx context.Context, payload []byte) ([]byte, error) {
-	return nil, errors.New("Native execution provider does not support execution via trigger subjects")
+	return nil, errors.New("native execution provider does not support execution via trigger subjects")
 }
 
 // Validate the underlying artifact to be a 64-bit linux native ELF
@@ -110,11 +110,11 @@ func (e *NativeExecutable) Validate() error {
 // convenience method to initialize an ELF execution provider
 func InitNexExecutionProviderNative(params *agentapi.ExecutionProviderParams) (*NativeExecutable, error) {
 	if params.WorkloadName == nil {
-		return nil, errors.New("Native execution provider requires a workload name parameter")
+		return nil, errors.New("native execution provider requires a workload name parameter")
 	}
 
 	if params.TmpFilename == nil {
-		return nil, errors.New("Native execution provider requires a temporary filename parameter")
+		return nil, errors.New("native execution provider requires a temporary filename parameter")
 	}
 
 	return &NativeExecutable{

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -309,7 +309,7 @@ func (v *V8) newV8Context(ctx context.Context) (*v8.Context, error) {
 		return nil, err
 	}
 
-	bucketedObj, err := v.newBucketedObjectValueFunctionTemplate(ctx)
+	bucketedObj, err := v.newBucketedObjectStoreFunctionTemplate(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func (v *V8) newV8Context(ctx context.Context) (*v8.Context, error) {
 }
 
 // obj := this.obj("bucket")
-func (v *V8) newBucketedObjectValueFunctionTemplate(ctx context.Context) (*v8.FunctionTemplate, error) {
+func (v *V8) newBucketedObjectStoreFunctionTemplate(ctx context.Context) (*v8.FunctionTemplate, error) {
 	bucketFunc := v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 		args := info.Args()
 		if len(args) == 0 {

--- a/agent/providers/lib/v8.go
+++ b/agent/providers/lib/v8.go
@@ -25,8 +25,6 @@ import (
 )
 
 const (
-	hostServicesObjectName = "hostServices"
-
 	hostServicesHTTPObjectName         = "http"
 	hostServicesHTTPGetFunctionName    = "get"
 	hostServicesHTTPPostFunctionName   = "post"
@@ -292,12 +290,31 @@ func (v *V8) initUtils() {
 func (v *V8) newV8Context(ctx context.Context) (*v8.Context, error) {
 	global := v8.NewObjectTemplate(v.iso)
 
-	hostServices, err := v.newHostServicesTemplate(ctx)
+	err := global.Set(hostServicesHTTPObjectName, v.newHTTPObjectTemplate(ctx))
 	if err != nil {
 		return nil, err
 	}
 
-	err = global.Set(hostServicesObjectName, hostServices)
+	bucketedKv, err := v.newBucketedKeyValueFunctionTemplate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = global.Set(hostServicesKVObjectName, bucketedKv)
+	if err != nil {
+		return nil, err
+	}
+
+	err = global.Set(hostServicesMessagingObjectName, v.newMessagingObjectTemplate(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	bucketedObj, err := v.newBucketedObjectValueFunctionTemplate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = global.Set(hostServicesObjectStoreObjectName, bucketedObj)
 	if err != nil {
 		return nil, err
 	}
@@ -305,30 +322,50 @@ func (v *V8) newV8Context(ctx context.Context) (*v8.Context, error) {
 	return v8.NewContext(v.iso, global), nil
 }
 
-func (v *V8) newHostServicesTemplate(ctx context.Context) (*v8.ObjectTemplate, error) {
-	hostServices := v8.NewObjectTemplate(v.iso)
+// obj := this.obj("bucket")
+func (v *V8) newBucketedObjectValueFunctionTemplate(ctx context.Context) (*v8.FunctionTemplate, error) {
+	bucketFunc := v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		args := info.Args()
+		if len(args) == 0 {
+			val, _ := v8.NewValue(v.iso, "bucket name is required")
+			return v.iso.ThrowException(val)
+		}
 
-	err := hostServices.Set(hostServicesHTTPObjectName, v.newHTTPObjectTemplate(ctx))
-	if err != nil {
-		return nil, err
-	}
+		obj := v.newObjectStoreObjectTemplate(ctx, args[0].String())
+		val, err := obj.NewInstance(v.ctx)
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
+		}
 
-	err = hostServices.Set(hostServicesKVObjectName, v.newKeyValueObjectTemplate(ctx))
-	if err != nil {
-		return nil, err
-	}
+		return val.Value
 
-	err = hostServices.Set(hostServicesMessagingObjectName, v.newMessagingObjectTemplate(ctx))
-	if err != nil {
-		return nil, err
-	}
+	})
 
-	err = hostServices.Set(hostServicesObjectStoreObjectName, v.newObjectStoreObjectTemplate(ctx))
-	if err != nil {
-		return nil, err
-	}
+	return bucketFunc, nil
+}
 
-	return hostServices, nil
+// kv := this.kv("bucket")
+func (v *V8) newBucketedKeyValueFunctionTemplate(ctx context.Context) (*v8.FunctionTemplate, error) {
+	bucketFunc := v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		args := info.Args()
+		if len(args) == 0 {
+			val, _ := v8.NewValue(v.iso, "bucket name is required")
+			return v.iso.ThrowException(val)
+		}
+
+		kv := v.newKeyValueObjectTemplate(ctx, args[0].String())
+		val, err := kv.NewInstance(v.ctx)
+		if err != nil {
+			val, _ := v8.NewValue(v.iso, err.Error())
+			return v.iso.ThrowException(val)
+		}
+
+		return val.Value
+
+	})
+
+	return bucketFunc, nil
 }
 
 func (v *V8) newHTTPObjectTemplate(ctx context.Context) *v8.ObjectTemplate {
@@ -438,7 +475,8 @@ func (v *V8) genHttpClientFunc(ctx context.Context, method string) func(info *v8
 	}
 }
 
-func (v *V8) newKeyValueObjectTemplate(ctx context.Context) *v8.ObjectTemplate {
+func (v *V8) newKeyValueObjectTemplate(ctx context.Context, bucketName string) *v8.ObjectTemplate {
+
 	kv := v8.NewObjectTemplate(v.iso)
 
 	_ = kv.Set(hostServicesKVGetFunctionName, v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
@@ -450,7 +488,7 @@ func (v *V8) newKeyValueObjectTemplate(ctx context.Context) *v8.ObjectTemplate {
 
 		key := args[0].String()
 
-		resp, err := v.builtins.KVGet(ctx, key)
+		resp, err := v.builtins.KVGet(ctx, bucketName, key)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -481,7 +519,7 @@ func (v *V8) newKeyValueObjectTemplate(ctx context.Context) *v8.ObjectTemplate {
 			return v.iso.ThrowException(val)
 		}
 
-		kvresp, err := v.builtins.KVSet(ctx, key, value)
+		kvresp, err := v.builtins.KVSet(ctx, bucketName, key, value)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -504,7 +542,7 @@ func (v *V8) newKeyValueObjectTemplate(ctx context.Context) *v8.ObjectTemplate {
 
 		key := args[0].String()
 
-		kvresp, err := v.builtins.KVDelete(ctx, key)
+		kvresp, err := v.builtins.KVDelete(ctx, bucketName, key)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -520,7 +558,7 @@ func (v *V8) newKeyValueObjectTemplate(ctx context.Context) *v8.ObjectTemplate {
 
 	_ = kv.Set(hostServicesKVKeysFunctionName, v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 
-		resp, err := v.builtins.KVKeys(ctx)
+		resp, err := v.builtins.KVKeys(ctx, bucketName)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -685,7 +723,7 @@ func (v *V8) newMessagingObjectTemplate(ctx context.Context) *v8.ObjectTemplate 
 	return messaging
 }
 
-func (v *V8) newObjectStoreObjectTemplate(ctx context.Context) *v8.ObjectTemplate {
+func (v *V8) newObjectStoreObjectTemplate(ctx context.Context, bucketName string) *v8.ObjectTemplate {
 	objectStore := v8.NewObjectTemplate(v.iso)
 
 	_ = objectStore.Set(hostServicesObjectStoreGetFunctionName, v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
@@ -696,7 +734,7 @@ func (v *V8) newObjectStoreObjectTemplate(ctx context.Context) *v8.ObjectTemplat
 		}
 
 		name := args[0].String()
-		resp, err := v.builtins.ObjectGet(ctx, name)
+		resp, err := v.builtins.ObjectGet(ctx, bucketName, name)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -727,7 +765,7 @@ func (v *V8) newObjectStoreObjectTemplate(ctx context.Context) *v8.ObjectTemplat
 			return v.iso.ThrowException(val)
 		}
 
-		resp, err := v.builtins.ObjectPut(ctx, name, value)
+		resp, err := v.builtins.ObjectPut(ctx, bucketName, name, value)
 
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
@@ -754,7 +792,7 @@ func (v *V8) newObjectStoreObjectTemplate(ctx context.Context) *v8.ObjectTemplat
 		}
 
 		name := args[0].String()
-		err := v.builtins.ObjectDelete(ctx, name)
+		err := v.builtins.ObjectDelete(ctx, bucketName, name)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)
@@ -764,7 +802,7 @@ func (v *V8) newObjectStoreObjectTemplate(ctx context.Context) *v8.ObjectTemplat
 	}))
 
 	_ = objectStore.Set(hostServicesObjectStoreListFunctionName, v8.NewFunctionTemplate(v.iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
-		resp, err := v.builtins.ObjectList(ctx)
+		resp, err := v.builtins.ObjectList(ctx, bucketName)
 		if err != nil {
 			val, _ := v8.NewValue(v.iso, err.Error())
 			return v.iso.ThrowException(val)

--- a/examples/nodeconfigs/hostservices_config.json
+++ b/examples/nodeconfigs/hostservices_config.json
@@ -19,8 +19,7 @@
         "services": {
             "kv": {
                 "enabled": true,
-                "config": {
-                    "bucket_name": "SAMPLEHSKV_${namespace}_${workload_name}",
+                "config": {                    
                     "max_bytes": 0,
                     "auto_provision": false
                 }

--- a/examples/nodeconfigs/hostservices_config.json
+++ b/examples/nodeconfigs/hostservices_config.json
@@ -22,7 +22,7 @@
                 "config": {
                     "bucket_name": "SAMPLEHSKV_${namespace}_${workload_name}",
                     "max_bytes": 0,
-                    "jit_provision": false
+                    "auto_provision": false
                 }
             },
             "messaging": {

--- a/examples/v8/echofunction/src/http.js
+++ b/examples/v8/echofunction/src/http.js
@@ -3,7 +3,7 @@
   let getEx;
 
   try {
-    get = this.hostServices.http.get('https://example.org');
+    get = this.http.get('https://example.org');
   } catch (e) {
     getEx = e;
   }
@@ -12,7 +12,7 @@
   let postEx;
 
   try {
-    post = this.hostServices.http.post('https://example.org', payload);
+    post = this.http.post('https://example.org', payload);
   } catch (e) {
     postEx = e;
   }
@@ -21,7 +21,7 @@
   let putEx;
 
   try {
-    put = this.hostServices.http.put('https://example.org', payload);
+    put = this.http.put('https://example.org', payload);
   } catch (e) {
     putEx = e;
   }
@@ -30,7 +30,7 @@
   let patchEx;
 
   try {
-    patch = this.hostServices.http.patch('https://example.org', payload);
+    patch = this.http.patch('https://example.org', payload);
   } catch (e) {
     patchEx = e;
   }
@@ -39,7 +39,7 @@
   let delEx;
 
   try {
-    del = this.hostServices.http.delete('https://example.org', payload);
+    del = this.http.delete('https://example.org', payload);
   } catch (e) {
     delEx = e;
   }
@@ -49,7 +49,7 @@
   let headEx;
 
   try {
-    head = this.hostServices.http.head('https://example.org');
+    head = this.http.head('https://example.org');
   } catch (e) {
     headEx = e;
   }

--- a/examples/v8/echofunction/src/kv.js
+++ b/examples/v8/echofunction/src/kv.js
@@ -1,10 +1,10 @@
 (subject, payload) => {
-  this.hostServices.kv.set('hello', payload);
-  this.hostServices.kv.delete('hello');
+  this.kv("testBucket").set('hello', payload);
+  this.kv("testBucket").delete('hello');
 
-  this.hostServices.kv.set('hello2', payload);
+  this.kv("testBucket").set('hello2', payload);
   return {
-    keys: this.hostServices.kv.keys(),
-    hello2: String.fromCharCode(...this.hostServices.kv.get('hello2'))
+    keys: this.kv("testBucket").keys(),
+    hello2: String.fromCharCode(...this.kv("testBucket").get('hello2'))
   }
 };

--- a/examples/v8/echofunction/src/messaging.js
+++ b/examples/v8/echofunction/src/messaging.js
@@ -1,5 +1,5 @@
 (subject, payload) => {
-  this.hostServices.messaging.publish('hello.world', payload);
+  this.messaging.publish('hello.world', payload);
 
   var reqResp;
   var reqEx;
@@ -8,7 +8,7 @@
   var reqManyEx;
 
   try {
-    reqResp = this.hostServices.messaging.request('hello.world.request', payload);
+    reqResp = this.messaging.request('hello.world.request', payload);
     reqResp = String.fromCharCode(...reqResp)
   } catch (e) {
     reqEx = e;

--- a/examples/v8/echofunction/src/objectstore.js
+++ b/examples/v8/echofunction/src/objectstore.js
@@ -1,10 +1,10 @@
 (subject, payload) => {
-  this.hostServices.objectStore.put('hello', payload);
-  this.hostServices.objectStore.delete('hello');
+  this.objectStore("testObjBucket").put('hello', payload);
+  this.objectStore("testObjBucket").delete('hello');
 
-  this.hostServices.objectStore.put('hello2', payload);
+  this.objectStore("testObjBucket").put('hello2', payload);
   return {
-    list: this.hostServices.objectStore.list(),
-    hello2: String.fromCharCode(...this.hostServices.objectStore.get('hello2'))
+    list: this.objectStore("testObjBucket").list(),
+    hello2: String.fromCharCode(...this.objectStore("testObjBucket").get('hello2'))
   }
 };

--- a/host-services/builtins/builtins_client.go
+++ b/host-services/builtins/builtins_client.go
@@ -27,9 +27,10 @@ func NewBuiltinServicesClient(hsClient *hostservices.HostServicesClient) *Builti
 	}
 }
 
-func (c *BuiltinServicesClient) KVGet(ctx context.Context, key string) ([]byte, error) {
+func (c *BuiltinServicesClient) KVGet(ctx context.Context, bucket string, key string) ([]byte, error) {
 	metadata := map[string]string{
-		agentapi.KeyValueKeyHeader: key,
+		agentapi.KeyValueKeyHeader:   key,
+		agentapi.BucketContextHeader: bucket,
 	}
 
 	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodGet, []byte{}, metadata)
@@ -44,9 +45,10 @@ func (c *BuiltinServicesClient) KVGet(ctx context.Context, key string) ([]byte, 
 	return resp.Data, nil
 }
 
-func (c *BuiltinServicesClient) KVSet(ctx context.Context, key string, value []byte) (*agentapi.HostServicesKeyValueResponse, error) {
+func (c *BuiltinServicesClient) KVSet(ctx context.Context, bucket string, key string, value []byte) (*agentapi.HostServicesKeyValueResponse, error) {
 	metadata := map[string]string{
-		agentapi.KeyValueKeyHeader: key,
+		agentapi.KeyValueKeyHeader:   key,
+		agentapi.BucketContextHeader: bucket,
 	}
 
 	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodSet, value, metadata)
@@ -66,9 +68,10 @@ func (c *BuiltinServicesClient) KVSet(ctx context.Context, key string, value []b
 	return &kvResponse, nil
 }
 
-func (c *BuiltinServicesClient) KVDelete(ctx context.Context, key string) (*agentapi.HostServicesKeyValueResponse, error) {
+func (c *BuiltinServicesClient) KVDelete(ctx context.Context, bucket string, key string) (*agentapi.HostServicesKeyValueResponse, error) {
 	metadata := map[string]string{
-		agentapi.KeyValueKeyHeader: key,
+		agentapi.KeyValueKeyHeader:   key,
+		agentapi.BucketContextHeader: bucket,
 	}
 
 	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodDelete, []byte{}, metadata)
@@ -88,8 +91,10 @@ func (c *BuiltinServicesClient) KVDelete(ctx context.Context, key string) (*agen
 	return &kvResponse, nil
 }
 
-func (c *BuiltinServicesClient) KVKeys(ctx context.Context) ([]string, error) {
-	metadata := map[string]string{}
+func (c *BuiltinServicesClient) KVKeys(ctx context.Context, bucket string) ([]string, error) {
+	metadata := map[string]string{
+		agentapi.BucketContextHeader: bucket,
+	}
 
 	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameKeyValue, kvServiceMethodKeys, []byte{}, metadata)
 	if err != nil {
@@ -152,9 +157,10 @@ func (c *BuiltinServicesClient) MessagingRequest(ctx context.Context, subject st
 	return resp.Data, nil
 }
 
-func (c *BuiltinServicesClient) ObjectGet(ctx context.Context, objectName string) ([]byte, error) {
+func (c *BuiltinServicesClient) ObjectGet(ctx context.Context, bucket string, objectName string) ([]byte, error) {
 	metadata := map[string]string{
 		agentapi.ObjectStoreObjectNameHeader: objectName,
+		agentapi.BucketContextHeader:         bucket,
 	}
 
 	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodGet, []byte{}, metadata)
@@ -168,8 +174,12 @@ func (c *BuiltinServicesClient) ObjectGet(ctx context.Context, objectName string
 	return resp.Data, nil
 }
 
-func (c *BuiltinServicesClient) ObjectList(ctx context.Context) ([]*nats.ObjectInfo, error) {
-	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodList, []byte{}, make(map[string]string))
+func (c *BuiltinServicesClient) ObjectList(ctx context.Context, bucket string) ([]*nats.ObjectInfo, error) {
+	metadata := map[string]string{
+		agentapi.BucketContextHeader: bucket,
+	}
+
+	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodList, []byte{}, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -186,9 +196,10 @@ func (c *BuiltinServicesClient) ObjectList(ctx context.Context) ([]*nats.ObjectI
 	return theList, nil
 }
 
-func (c *BuiltinServicesClient) ObjectPut(ctx context.Context, objectName string, payload []byte) (*nats.ObjectInfo, error) {
+func (c *BuiltinServicesClient) ObjectPut(ctx context.Context, bucket string, objectName string, payload []byte) (*nats.ObjectInfo, error) {
 	metadata := map[string]string{
 		agentapi.ObjectStoreObjectNameHeader: objectName,
+		agentapi.BucketContextHeader:         bucket,
 	}
 	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodPut, payload, metadata)
 	if err != nil {
@@ -206,9 +217,10 @@ func (c *BuiltinServicesClient) ObjectPut(ctx context.Context, objectName string
 	return &result, nil
 }
 
-func (c *BuiltinServicesClient) ObjectDelete(ctx context.Context, objectName string) error {
+func (c *BuiltinServicesClient) ObjectDelete(ctx context.Context, bucket string, objectName string) error {
 	metadata := map[string]string{
 		agentapi.ObjectStoreObjectNameHeader: objectName,
+		agentapi.BucketContextHeader:         bucket,
 	}
 	resp, err := c.hsClient.PerformRPC(ctx, builtinServiceNameObjectStore, objectStoreServiceMethodDelete, []byte{}, metadata)
 	if err != nil {

--- a/host-services/builtins/objectstore.go
+++ b/host-services/builtins/objectstore.go
@@ -81,7 +81,11 @@ func (o *ObjectStoreService) HandleRequest(
 	objectStore, err := o.resolveObjectStore(nc, objectStoreName)
 	if err != nil {
 		o.log.Warn(fmt.Sprintf("failed to resolve object store: %s", err.Error()))
-		return hostservices.ServiceResultFail(500, "unable to resolve object store"), nil
+		code := uint(500)
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			code = 404
+		}
+		return hostservices.ServiceResultFail(code, "unable to resolve object store"), nil
 	}
 
 	switch method {

--- a/host-services/server.go
+++ b/host-services/server.go
@@ -162,8 +162,13 @@ func (h *HostServicesServer) handleRPC(msg *nats.Msg) {
 	}
 
 	span.AddEvent("RPC Request Completed")
+	var serverMsg *nats.Msg
+	if result.IsError() {
+		serverMsg = serverFailMessage(msg.Reply, result.Code, result.Message)
+	} else {
+		serverMsg = serverSuccessMessage(msg.Reply, result.Code, result.Data, messageOk)
+	}
 
-	serverMsg := serverSuccessMessage(msg.Reply, result.Code, result.Data, messageOk)
 	_ = msg.RespondMsg(serverMsg)
 }
 

--- a/host-services/service_test.go
+++ b/host-services/service_test.go
@@ -45,7 +45,7 @@ func TestBogusService(t *testing.T) {
 	client := NewHostServicesClient(nc, 2*time.Second, testNamespace, testWorkload, testWorkloadId)
 
 	boguss := bogusService{
-		code:    99,
+		code:    200,
 		message: "howdy",
 		data:    []byte{1, 2, 3, 4, 5, 6},
 	}
@@ -69,10 +69,10 @@ func TestBogusService(t *testing.T) {
 	}
 
 	if !slices.Equal(result.Data, []byte{1, 2, 3, 4, 5, 6}) {
-		t.Fatalf("Data did not round trip properly: %+v", result.Data)
+		t.Fatalf("Data did not round trip properly: %+v", result)
 	}
 
-	if result.Code != 99 {
+	if result.Code != 200 {
 		t.Fatalf("Code did not return properly: %d", result.Code)
 	}
 }

--- a/internal/agent-api/client.go
+++ b/internal/agent-api/client.go
@@ -31,12 +31,10 @@ const (
 	NexTriggerSubject = "x-nex-trigger-subject"
 	NexRuntimeNs      = "x-nex-runtime-ns"
 
-	HttpURLHeader = "x-http-url"
-
-	KeyValueKeyHeader = "x-keyvalue-key"
-
-	MessagingSubjectHeader = "x-subject"
-
+	HttpURLHeader               = "x-http-url"
+	KeyValueKeyHeader           = "x-keyvalue-key"
+	BucketContextHeader         = "x-context-bucket"
+	MessagingSubjectHeader      = "x-subject"
 	ObjectStoreObjectNameHeader = "x-object-name"
 )
 
@@ -270,7 +268,7 @@ func (a *AgentClient) MarkUnselected() {
 
 func (a *AgentClient) RunTrigger(ctx context.Context, tracer trace.Tracer, subject string, data []byte) (*nats.Msg, error) {
 	intmsg := nats.NewMsg(fmt.Sprintf("agentint.%s.trigger", a.agentID))
-	intmsg.Header.Add(NexTriggerSubject, subject)
+	intmsg.Header.Add(string(NexTriggerSubject), subject)
 	intmsg.Data = data
 
 	cctx, childSpan := tracer.Start(

--- a/spec/spec_suite_test.go
+++ b/spec/spec_suite_test.go
@@ -114,6 +114,22 @@ func startNATS(storeDir string) (*server.Server, *nats.Conn, *int, error) {
 		return nil, nil, nil, fmt.Errorf("failed to create jetstream object store: %s", err)
 	}
 
+	_, err = js.CreateObjectStore(&nats.ObjectStoreConfig{
+		Bucket:  "testObjBucket",
+		Storage: nats.MemoryStorage,
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create jetstream object store: %s", err)
+	}
+
+	_, err = js.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket:  "testBucket",
+		Storage: nats.MemoryStorage,
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create jetstream kv store: %s", err)
+	}
+
 	return ns, nc, &port, nil
 }
 


### PR DESCRIPTION
This PR does a few main things:

* changes behavior so that host services resources (currently kv, objectStore) are _never_ automatically provisioned
* JS API for host services has been changed as per #332 
* Fixed a bug in host services calls that didn't return an error propagated from the service itself