### PR TITLE
stops infinite recursion. attempts to clarify difference between the 2 deploy requests

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -175,7 +175,7 @@ func (a *Agent) Version() string {
 // the executable workload artifact from the cache bucket, write it to a
 // temporary file and make it executable; this method returns the full
 // path to the cached artifact if successful
-func (a *Agent) cacheExecutableArtifact(req *agentapi.DeployRequest) (*string, error) {
+func (a *Agent) cacheExecutableArtifact(req *agentapi.AgentWorkloadInfo) (*string, error) {
 	fileName := fmt.Sprintf("workload-%s", *a.md.VmID)
 	tempFile := path.Join(os.TempDir(), fileName)
 
@@ -260,7 +260,7 @@ func (a *Agent) dispatchLogs() {
 // bucket, write it to tmp, initialize the execution provider per the
 // request, and then validate and deploy a workload
 func (a *Agent) handleDeploy(m *nats.Msg) {
-	var request agentapi.DeployRequest
+	var request agentapi.AgentWorkloadInfo
 	err := json.Unmarshal(m.Data, &request)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to unmarshal deploy request: %s", err)
@@ -455,7 +455,7 @@ func (a *Agent) installSignalHandlers() {
 
 // newExecutionProviderParams initializes new execution provider params
 // for the given work request and starts a goroutine listening
-func (a *Agent) newExecutionProviderParams(req *agentapi.DeployRequest, tmpFile string) (*agentapi.ExecutionProviderParams, error) {
+func (a *Agent) newExecutionProviderParams(req *agentapi.AgentWorkloadInfo, tmpFile string) (*agentapi.ExecutionProviderParams, error) {
 	if a.md.VmID == nil {
 		return nil, errors.New("vm id is required to initialize execution provider params")
 	}
@@ -465,11 +465,11 @@ func (a *Agent) newExecutionProviderParams(req *agentapi.DeployRequest, tmpFile 
 	}
 
 	params := &agentapi.ExecutionProviderParams{
-		DeployRequest: *req,
-		Stderr:        &logEmitter{stderr: true, name: *req.WorkloadName, logs: a.agentLogs},
-		Stdout:        &logEmitter{stderr: false, name: *req.WorkloadName, logs: a.agentLogs},
-		TmpFilename:   &tmpFile,
-		VmID:          *a.md.VmID,
+		AgentWorkloadInfo: *req,
+		Stderr:            &logEmitter{stderr: true, name: *req.WorkloadName, logs: a.agentLogs},
+		Stdout:            &logEmitter{stderr: false, name: *req.WorkloadName, logs: a.agentLogs},
+		TmpFilename:       &tmpFile,
+		VmID:              *a.md.VmID,
 
 		Fail: make(chan bool),
 		Run:  make(chan bool),

--- a/agent/providers/plugins_test.go
+++ b/agent/providers/plugins_test.go
@@ -13,7 +13,7 @@ func TestNoopPluginLoad(t *testing.T) {
 	plugPath := "../../test/fixtures"
 	wName := "echofunctionjs"
 	params := &agentapi.ExecutionProviderParams{
-		DeployRequest: agentapi.DeployRequest{
+		AgentWorkloadInfo: agentapi.AgentWorkloadInfo{
 			WorkloadName: &wName,
 			WorkloadType: "noop",
 		},

--- a/internal/agent-api/types.go
+++ b/internal/agent-api/types.go
@@ -21,7 +21,7 @@ const DefaultRunloopSleepTimeoutMillis = 25
 
 // ExecutionProviderParams parameters for initializing a specific execution provider
 type ExecutionProviderParams struct {
-	DeployRequest
+	AgentWorkloadInfo
 	TriggerSubjects []string `json:"trigger_subjects"`
 
 	// Fail channel receives bool upon command failing to start
@@ -45,8 +45,8 @@ type ExecutionProviderParams struct {
 	PluginPath *string `json:"-"`
 }
 
-// DeployRequest processed by the agent
-type DeployRequest struct {
+// AgentWorkloadInfo processed by the agent
+type AgentWorkloadInfo struct {
 	Argv          []string          `json:"argv,omitempty"`
 	DecodedClaims jwt.GenericClaims `json:"-"`
 	Description   *string           `json:"description"`
@@ -68,34 +68,29 @@ type DeployRequest struct {
 	Stdout      io.Writer `json:"-"`
 	TmpFilename *string   `json:"-"`
 
-	EncryptedEnvironment *string  `json:"-"`
-	JsDomain             *string  `json:"-"`
-	Location             *url.URL `json:"-"`
-	SenderPublicKey      *string  `json:"-"`
-	TargetNode           *string  `json:"-"`
-	WorkloadJwt          *string  `json:"-"`
+	Location *url.URL `json:"-"`
 
 	Errors []error `json:"errors,omitempty"`
 }
 
-func (request *DeployRequest) IsEssential() bool {
+func (request *AgentWorkloadInfo) IsEssential() bool {
 	return request.Essential != nil && *request.Essential
 }
 
 // Returns true if the run request supports essential flag
-func (request *DeployRequest) SupportsEssential() bool {
+func (request *AgentWorkloadInfo) SupportsEssential() bool {
 	return request.WorkloadType == controlapi.NexWorkloadNative ||
 		request.WorkloadType == controlapi.NexWorkloadOCI
 }
 
 // Returns true if the run request supports trigger subjects
-func (request *DeployRequest) SupportsTriggerSubjects() bool {
+func (request *AgentWorkloadInfo) SupportsTriggerSubjects() bool {
 	return (request.WorkloadType == controlapi.NexWorkloadV8 ||
 		request.WorkloadType == controlapi.NexWorkloadWasm) &&
 		len(request.TriggerSubjects) > 0
 }
 
-func (r *DeployRequest) Validate() error {
+func (r *AgentWorkloadInfo) Validate() error {
 	var err error
 
 	if r.Namespace == nil {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -695,28 +695,23 @@ func (n *Node) shuttingDown() bool {
 
 // For the curious - I tried a number of ways of making a common/shared deploy request and only modeling the differences
 // here, but it made all the code that creates deployment requests look hideous. Will look into cleaning this up again.
-func agentDeployRequestFromControlDeployRequest(request *controlapi.DeployRequest, namespace string, numBytes uint64, hash string) *agentapi.DeployRequest {
-	return &agentapi.DeployRequest{
-		Argv:                 request.Argv,
-		DecodedClaims:        request.DecodedClaims,
-		Description:          request.Description,
-		EncryptedEnvironment: request.Environment,
-		Environment:          request.WorkloadEnvironment,
-		Essential:            request.Essential,
-		Hash:                 hash,
-		HostServicesConfig:   request.HostServicesConfig,
-		ID:                   request.ID,
-		JsDomain:             request.JsDomain,
-		Location:             request.Location,
-		Namespace:            &namespace,
-		RetriedAt:            request.RetriedAt,
-		RetryCount:           request.RetryCount,
-		SenderPublicKey:      request.SenderPublicKey,
-		TargetNode:           request.TargetNode,
-		TotalBytes:           int64(numBytes),
-		TriggerSubjects:      request.TriggerSubjects,
-		WorkloadJwt:          request.WorkloadJWT,
-		WorkloadName:         request.WorkloadName,
-		WorkloadType:         request.WorkloadType,
+func agentDeployRequestFromControlDeployRequest(request *controlapi.DeployRequest, namespace string, numBytes uint64, hash string) *agentapi.AgentWorkloadInfo {
+	return &agentapi.AgentWorkloadInfo{
+		Argv:               request.Argv,
+		DecodedClaims:      request.DecodedClaims,
+		Description:        request.Description,
+		Environment:        request.WorkloadEnvironment,
+		Essential:          request.Essential,
+		Hash:               hash,
+		HostServicesConfig: request.HostServicesConfig,
+		ID:                 request.ID,
+		Location:           request.Location,
+		Namespace:          &namespace,
+		RetriedAt:          request.RetriedAt,
+		RetryCount:         request.RetryCount,
+		TotalBytes:         int64(numBytes),
+		TriggerSubjects:    request.TriggerSubjects,
+		WorkloadName:       request.WorkloadName,
+		WorkloadType:       request.WorkloadType,
 	}
 }

--- a/internal/node/processmanager/firecracker_procman.go
+++ b/internal/node/processmanager/firecracker_procman.go
@@ -39,7 +39,7 @@ type FirecrackerProcessManager struct {
 	natsint *internalnats.InternalNatsServer
 
 	delegate       ProcessDelegate
-	deployRequests map[string]*agentapi.DeployRequest
+	deployRequests map[string]*agentapi.AgentWorkloadInfo
 }
 
 func NewFirecrackerProcessManager(
@@ -61,7 +61,7 @@ func NewFirecrackerProcessManager(
 		allVMs:         make(map[string]*runningFirecracker),
 		poolVMs:        make(chan *runningFirecracker, config.MachinePoolSize),
 		stopMutex:      make(map[string]*sync.Mutex),
-		deployRequests: make(map[string]*agentapi.DeployRequest),
+		deployRequests: make(map[string]*agentapi.AgentWorkloadInfo),
 	}, nil
 }
 
@@ -95,7 +95,7 @@ func (f *FirecrackerProcessManager) EnterLameDuck() error {
 }
 
 // Preparing a workload reads from the warmVMs channel
-func (f *FirecrackerProcessManager) PrepareWorkload(workloadId string, deployRequest *agentapi.DeployRequest) error {
+func (f *FirecrackerProcessManager) PrepareWorkload(workloadId string, deployRequest *agentapi.AgentWorkloadInfo) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 

--- a/internal/node/processmanager/process_mgr.go
+++ b/internal/node/processmanager/process_mgr.go
@@ -10,7 +10,7 @@ const runloopSleepInterval = 100 * time.Millisecond
 
 // Information about an agent process without regard to the implementation of the agent process manager
 type ProcessInfo struct {
-	DeployRequest *agentapi.DeployRequest
+	DeployRequest *agentapi.AgentWorkloadInfo
 	ID            string
 	Name          string
 	Namespace     string
@@ -37,7 +37,7 @@ type ProcessManager interface {
 
 	// Associate a deploy request with the given workload id, and perform any
 	// just in time initialization of resources if necessary
-	PrepareWorkload(id string, request *agentapi.DeployRequest) error
+	PrepareWorkload(id string, request *agentapi.AgentWorkloadInfo) error
 
 	// Start the process manager and allocate a pool of agents based on an implementation-specific
 	// strategy, delegating callbacks to the given delegate

--- a/internal/node/processmanager/running_vm.go
+++ b/internal/node/processmanager/running_vm.go
@@ -32,7 +32,7 @@ type runningFirecracker struct {
 
 	closing         uint32
 	config          *nexmodels.NodeConfiguration
-	deployRequest   *agentapi.DeployRequest
+	deployRequest   *agentapi.AgentWorkloadInfo
 	ip              net.IP
 	log             *slog.Logger
 	machine         *firecracker.Machine

--- a/internal/node/processmanager/spawn_procman.go
+++ b/internal/node/processmanager/spawn_procman.go
@@ -38,14 +38,14 @@ type SpawningProcessManager struct {
 	natsint *internalnats.InternalNatsServer
 
 	delegate       ProcessDelegate
-	deployRequests map[string]*agentapi.DeployRequest
+	deployRequests map[string]*agentapi.AgentWorkloadInfo
 
 	log *slog.Logger
 }
 
 type spawnedProcess struct {
 	cmd             *exec.Cmd
-	deployRequest   *agentapi.DeployRequest
+	deployRequest   *agentapi.AgentWorkloadInfo
 	workloadStarted time.Time
 
 	ID string
@@ -74,7 +74,7 @@ func NewSpawningProcessManager(
 
 		stopMutexes: make(map[string]*sync.Mutex),
 
-		deployRequests: make(map[string]*agentapi.DeployRequest),
+		deployRequests: make(map[string]*agentapi.AgentWorkloadInfo),
 		allProcs:       make(map[string]*spawnedProcess),
 		poolProcs:      make(chan *spawnedProcess, config.MachinePoolSize),
 	}, nil
@@ -110,7 +110,7 @@ func (s *SpawningProcessManager) EnterLameDuck() error {
 }
 
 // Attaches a deployment request to a running process. Until a process is prepared, it's just an empty agent
-func (s *SpawningProcessManager) PrepareWorkload(workloadID string, deployRequest *agentapi.DeployRequest) error {
+func (s *SpawningProcessManager) PrepareWorkload(workloadID string, deployRequest *agentapi.AgentWorkloadInfo) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -216,7 +216,7 @@ func (m *WorkloadManager) CacheWorkload(workloadID string, request *controlapi.D
 
 // Deploy a workload as specified by the given deploy request to an available
 // agent in the configured pool
-func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, request *agentapi.DeployRequest) error {
+func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, request *agentapi.AgentWorkloadInfo) error {
 	w.poolMutex.Lock()
 	defer w.poolMutex.Unlock()
 
@@ -318,7 +318,7 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 
 // Locates a given workload by its workload ID and returns the deployment request associated with it
 // Note that this means "pending" agents are not considered by lookups
-func (w *WorkloadManager) LookupWorkload(workloadID string) (*agentapi.DeployRequest, error) {
+func (w *WorkloadManager) LookupWorkload(workloadID string) (*agentapi.AgentWorkloadInfo, error) {
 	if agentClient, ok := w.liveAgents[workloadID]; ok {
 		return agentClient.DeployRequest(), nil
 	}
@@ -532,7 +532,7 @@ func (w *WorkloadManager) agentContactLost(workloadID string) {
 }
 
 // Generate a NATS subscriber function that is used to trigger function-type workloads
-func (w *WorkloadManager) generateTriggerHandler(workloadID string, tsub string, request *agentapi.DeployRequest) func(msg *nats.Msg) {
+func (w *WorkloadManager) generateTriggerHandler(workloadID string, tsub string, request *agentapi.AgentWorkloadInfo) func(msg *nats.Msg) {
 	agentClient, ok := w.liveAgents[workloadID]
 	if !ok {
 		w.log.Error("Attempted to generate trigger handler for non-existent agent client")
@@ -632,7 +632,7 @@ func (w *WorkloadManager) startInternalNATS() error {
 	return nil
 }
 
-func (w *WorkloadManager) createHostServicesConnection(request *agentapi.DeployRequest) (*nats.Conn, error) {
+func (w *WorkloadManager) createHostServicesConnection(request *agentapi.AgentWorkloadInfo) (*nats.Conn, error) {
 	natsOpts := []nats.Option{
 		nats.Name("nex-hostservices"),
 	}

--- a/test/wasm_test.go
+++ b/test/wasm_test.go
@@ -13,7 +13,7 @@ func TestWasmExecution(t *testing.T) {
 	file := "../examples/wasm/echofunction/echofunction.wasm"
 	typ := controlapi.NexWorkloadWasm
 	params := &agentapi.ExecutionProviderParams{
-		DeployRequest: agentapi.DeployRequest{
+		AgentWorkloadInfo: agentapi.AgentWorkloadInfo{
 			Environment:  map[string]string{},
 			Hash:         "",
 			TotalBytes:   0,
@@ -34,7 +34,7 @@ func TestWasmExecution(t *testing.T) {
 
 		NATSConn: nil, // FIXME
 	}
-	params.DeployRequest.WorkloadType = typ
+	params.AgentWorkloadInfo.WorkloadType = typ
 	wasm, err := lib.InitNexExecutionProviderWasm(params)
 	if err != nil {
 		t.Fatalf("Failed to instantiate wasm provider: %s", err)


### PR DESCRIPTION
In addition to the minor fix, there's a few renames and the removal of unused properties. There is a lot more work to do on refactoring how we're using the internal agent deploy "command" and the external control deploy "request". What I've done here is just what can be done without having to rewrite any functions.
