### PR TITLE
Ensure jetstream domain is configured for object digest lookup

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -357,7 +357,12 @@ func (n *Node) handleAutostarts() {
 		// functions cannot be essential
 		essential := autostart.Essential && autostart.WorkloadType == controlapi.NexWorkloadNative
 
-		js, err := n.nc.JetStream()
+		jsOpts := []nats.JSOpt{}
+		if autostart.JsDomain != nil {
+			jsOpts = append(jsOpts, nats.Domain(*autostart.JsDomain))
+		}
+
+		js, err := n.nc.JetStream(jsOpts...)
 		if err != nil {
 			n.log.Error("failed to resolve jetstream",
 				slog.String("error", err.Error()),

--- a/internal/node/workload_mgr_events.go
+++ b/internal/node/workload_mgr_events.go
@@ -72,31 +72,10 @@ func (w *WorkloadManager) agentEvent(agentId string, evt cloudevents.Event) {
 			}
 			id := reqUUID.String()
 
-			js, err := w.nc.JetStream()
-			if err != nil {
-				w.log.Error("Failed to resolve jetstream", slog.Any("err", err))
-				return
-			}
-
-			bucket, err := js.ObjectStore(agentWorkloadInfo.Location.Hostname())
-			if err != nil {
-				w.log.Error("Failed to resolve workload object store", slog.Any("err", err))
-				return
-			}
-
-			artifact := agentWorkloadInfo.Location.Path[1:len(agentWorkloadInfo.Location.Path)]
-
-			info, err := bucket.GetInfo(artifact)
-			if err != nil {
-				w.log.Error("Failed to resolve workload artifact: %s; %s", artifact, slog.Any("err", err))
-				return
-			}
-			digest := controlapi.SanitizeNATSDigest(info.Digest)
-
 			req, _ := json.Marshal(&controlapi.DeployRequest{
 				Argv:               agentWorkloadInfo.Argv,
 				Description:        agentWorkloadInfo.Description,
-				Hash:               &digest,
+				Hash:               &agentWorkloadInfo.Hash,
 				Environment:        agentWorkloadInfo.EncryptedEnvironment,
 				Essential:          agentWorkloadInfo.Essential,
 				HostServicesConfig: agentWorkloadInfo.HostServicesConfig,


### PR DESCRIPTION
Fix a bug introduced by looking up the object hash for autostart workload artifacts via jetstream without consideration of a configured jetstream domain.