### PR TITLE
allows the same file hash across 2 namespaces now

### DIFF
--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -222,9 +222,13 @@ func (w *WorkloadManager) DeployWorkload(agentClient *agentapi.AgentClient, requ
 
 	if w.config.AllowDuplicateWorkloads != nil && !*w.config.AllowDuplicateWorkloads {
 		for _, agentClient := range w.liveAgents {
-			if strings.EqualFold(agentClient.WorkloadInfo().Hash, request.Hash) {
+			// if the hash AND namespace match, then reject the dupe
+			if strings.EqualFold(agentClient.WorkloadInfo().Hash, request.Hash) &&
+				request.Namespace != nil &&
+				strings.EqualFold(*agentClient.WorkloadInfo().Namespace, *request.Namespace) {
 				w.log.Warn("Attempted to deploy duplicate workload",
 					slog.String("workload_name", *request.WorkloadName),
+					slog.String("hash", request.Hash),
 					slog.String("workload_type", string(request.WorkloadType)),
 				)
 


### PR DESCRIPTION
In the code in `main`, if two people attempt to deploy the same workload (e.g. a tutorial binary or JavaScript function) , then the node would reject it as a duplicate. 

now, the namespace is the boundary for dupe checking on hashes, allowing 2 different namespaces to run the same binaries without hitting the "no duplicates" limit.