### PR TITLE
adds id to workload info

### DIFF
--- a/internal/node/workload_mgr.go
+++ b/internal/node/workload_mgr.go
@@ -367,6 +367,7 @@ func (w *WorkloadManager) RunningWorkloads() ([]controlapi.MachineSummary, error
 			Uptime:    uptimeFriendly,
 			Namespace: *deployRequest.Namespace,
 			Workload: controlapi.WorkloadSummary{
+				ID:           id,
 				Name:         *deployRequest.WorkloadName,
 				Description:  *deployRequest.Description,
 				Hash:         deployRequest.Hash,


### PR DESCRIPTION
This change doesn't really "fix" anything, however, if a consumer of the control API was relying on having the workload ID available in the workload instance payload, it would've been blank before.