### PR TITLE
adds a sample actor interaction for querying the list of running workloads from the info endpoint

### DIFF
--- a/node/actors/control_api.go
+++ b/node/actors/control_api.go
@@ -269,6 +269,6 @@ func respondEnvelope(m *nats.Msg, dataType string, code int, data interface{}, e
 	if len(strings.TrimSpace(err)) == 0 {
 		e = nil
 	}
-	bytes, _ := json.Marshal(newEnvelope(dataType, data, code, &err))
+	bytes, _ := json.Marshal(newEnvelope(dataType, data, code, e))
 	_ = m.Respond(bytes)
 }

--- a/node/actors/control_api.go
+++ b/node/actors/control_api.go
@@ -256,14 +256,6 @@ func newEnvelope(dataType string, data interface{}, code int, err *string) Envel
 	}
 }
 
-func failEnvelope(dataType string, code int, err string) Envelope {
-	return Envelope{
-		PayloadType: dataType,
-		Code:        code,
-		Error:       &err,
-	}
-}
-
 func respondEnvelope(m *nats.Msg, dataType string, code int, data interface{}, err string) {
 	e := &err
 	if len(strings.TrimSpace(err)) == 0 {

--- a/node/actors/control_api.go
+++ b/node/actors/control_api.go
@@ -181,16 +181,19 @@ func (api *ControlAPI) handleInfo(m *nats.Msg) {
 	ctx := context.Background()
 	_, agentSuper, err := api.self.ActorSystem().ActorOf(ctx, AgentSupervisorActorName)
 	if err != nil {
-		// TODO: do something
+		api.logger.Error("Failed to locate agent supervisor actor", slog.Any("error", err))
+		return
 	}
 	// Ask the agent supervisor for a list of all the workloads from all of its children
 	response, err := api.self.Ask(ctx, agentSuper, req)
 	if err != nil {
-		// TODO: TODO
+		api.logger.Error("Failed to get list of running workloads from agent supervisor", slog.Any("error", err))
+		return
 	}
 	workloadResponse, ok := response.(*actorproto.WorkloadListing)
 	if !ok {
-		// TODO: TODO
+		api.logger.Error("Workload listing response from agent supervisor was not the correct type")
+		return
 	}
 
 	// TODO: This struct will be replaced by a generated struct from a JSON schema in api/nodecontrol
@@ -204,7 +207,8 @@ func (api *ControlAPI) handleInfo(m *nats.Msg) {
 
 	bytes, err := json.Marshal(&info)
 	if err != nil {
-		// TODO: TODO
+		api.logger.Error("Failed to marshal node info to JSON", slog.Any("error", err))
+		return
 	}
 
 	_ = m.Respond(bytes)

--- a/node/actors/direct_start_agent.go
+++ b/node/actors/direct_start_agent.go
@@ -7,6 +7,8 @@ import (
 	goakt "github.com/tochemey/goakt/v2/actors"
 	"github.com/tochemey/goakt/v2/goaktpb"
 	"github.com/tochemey/goakt/v2/log"
+
+	actorproto "github.com/synadia-io/nex/node/actors/pb"
 )
 
 const DirectStartActorName = "direct_start"
@@ -34,7 +36,17 @@ func (a *DirectStartAgent) Receive(ctx *goakt.ReceiveContext) {
 	case *goaktpb.PostStart:
 		a.logger = ctx.Self().Logger()
 		a.logger.Infof("Direct start agent '%v' is running", ctx.Self().Name())
+	case *actorproto.QueryWorkloads:
+		a.queryWorkloads(ctx)
 	default:
 		ctx.Unhandled()
 	}
+}
+
+func (a *DirectStartAgent) queryWorkloads(ctx *goakt.ReceiveContext) {
+	// TODO: make this real
+
+	results := make([]*actorproto.WorkloadSummary, 0)
+	listing := &actorproto.WorkloadListing{Workloads: results}
+	ctx.Response(listing)
 }

--- a/node/actors/external_agent.go
+++ b/node/actors/external_agent.go
@@ -7,6 +7,8 @@ import (
 	goakt "github.com/tochemey/goakt/v2/actors"
 	"github.com/tochemey/goakt/v2/goaktpb"
 	"github.com/tochemey/goakt/v2/log"
+
+	actorproto "github.com/synadia-io/nex/node/actors/pb"
 )
 
 type ExternalAgent struct {
@@ -32,7 +34,17 @@ func (a *ExternalAgent) Receive(ctx *goakt.ReceiveContext) {
 	case *goaktpb.PostStart:
 		a.logger = ctx.Self().Logger()
 		a.logger.Infof("External agent for workload type '%s' is running", ctx.Self().Name())
+	case *actorproto.QueryWorkloads:
+		a.queryWorkloads(ctx)
 	default:
 		ctx.Unhandled()
 	}
+}
+
+func (a *ExternalAgent) queryWorkloads(ctx *goakt.ReceiveContext) {
+	// TODO: make this real
+
+	results := make([]*actorproto.WorkloadSummary, 0)
+	listing := &actorproto.WorkloadListing{Workloads: results}
+	ctx.Response(listing)
 }


### PR DESCRIPTION
Note that there is some implementation stuff that hasn't happened yet because neither of the agent actors are currently  maintaining their workload list. Once they do that, we can fill in the "make this real" bits with the actual list of workloads.