### PR TITLE
fixes the connection and credentials

### DIFF
--- a/agents/common/agent_client.go
+++ b/agents/common/agent_client.go
@@ -1,0 +1,14 @@
+package agentcommon
+
+import "github.com/nats-io/nats.go"
+
+// An agent client is used by a Nex node host to communicate with
+// an agent.
+type AgentClient struct {
+	internalNatsConn *nats.Conn
+	agentName        string
+}
+
+func NewAgentClient(nc *nats.Conn, name string) (*AgentClient, error) {
+	return &AgentClient{internalNatsConn: nc, agentName: name}, nil
+}

--- a/node/internal/actors/internal_nats_server.go
+++ b/node/internal/actors/internal_nats_server.go
@@ -86,6 +86,10 @@ func (ns *InternalNatsServer) CredentialsMap() map[string]AgentCredential {
 	return out
 }
 
+func (ns *InternalNatsServer) HostUserKeypair() nkeys.KeyPair {
+	return ns.hostUser
+}
+
 func (ns *InternalNatsServer) PreStart(ctx context.Context) error {
 	return nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -234,8 +234,12 @@ func (nn *nexNode) initializeSupervisionTree() error {
 	for _, agent := range nn.options.AgentOptions {
 		// This map lookup works because the agent name is identical to the workload type
 		_, err := agentSuper.SpawnChild(nn.ctx, agent.Name,
-			actors.CreateExternalAgent(nn.options.Logger.WithGroup(agent.Name),
-				allCreds[agent.Name], agent, nn.options))
+			actors.CreateExternalAgent(
+				nn.options.Logger.WithGroup(agent.Name),
+				allCreds[agent.Name],
+				inats.HostUserKeypair(),
+				agent,
+				nn.options))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Creates an instance of the new `AgentClient` and renames some fields to make it more clear when the actor is managing creds for its own internal use versus passing them down into the agent binary. This should be the last of the "pre" PRs before I push up a PR with a functioning external agent.