### PR TITLE
javascript runner

### DIFF
--- a/agents/javascript/agent.go
+++ b/agents/javascript/agent.go
@@ -14,10 +14,16 @@ var _ agentcommon.AgentCallback = &JavaScriptAgent{}
 
 type JavaScriptAgent struct {
 	workloads map[string]*agentapigen.StartWorkloadRequestJson
+	runner    *ScriptRunner
+}
+
+func newProvider(workloadId string, allocator vmAllocator) hostServiceProvider {
+	return NewNodeHostServicesProvider(workloadId, allocator)
 }
 
 func NewAgent() (*JavaScriptAgent, error) {
 	return &JavaScriptAgent{
+		runner:    NewScriptRunner(newProvider),
 		workloads: make(map[string]*agentapigen.StartWorkloadRequestJson),
 	}, nil
 }
@@ -39,11 +45,18 @@ func (a *JavaScriptAgent) Preflight() error {
 
 func (a *JavaScriptAgent) StartWorkload(req *agentapigen.StartWorkloadRequestJson) error {
 	a.workloads[req.WorkloadId] = req
+	// TODO: get script file
+
+	// TODO: call AddScript on runner
+
 	return nil
 }
 
 func (a *JavaScriptAgent) StopWorkload(req *agentapigen.StopWorkloadRequestJson) error {
 	delete(a.workloads, req.WorkloadId)
+
+	// TODO: call RemoveScript on runner
+
 	return nil
 }
 

--- a/agents/javascript/go.mod
+++ b/agents/javascript/go.mod
@@ -7,10 +7,15 @@ replace github.com/synadia-io/nex => ../..
 require github.com/synadia-io/nex v0.0.0-00010101000000-000000000000
 
 require (
+	github.com/dlclark/regexp2 v1.11.4 // indirect
+	github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd // indirect
+	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
+	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/nats-io/nats.go v1.37.0 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/text v0.19.0 // indirect
 )

--- a/agents/javascript/go.sum
+++ b/agents/javascript/go.sum
@@ -1,3 +1,11 @@
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd h1:QMSNEh9uQkDjyPwu/J541GgSH+4hw+0skJDIj9HJ3mE=
+github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=
@@ -10,3 +18,5 @@ golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
+golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=

--- a/agents/javascript/node_hs_provider.go
+++ b/agents/javascript/node_hs_provider.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+// TODO: implement this using the builtins client for host services
+type NodeHostServicesProvider struct {
+	workloadId string
+	allocator  vmAllocator
+}
+
+var _ hostServiceProvider = &NodeHostServicesProvider{}
+
+func NewNodeHostServicesProvider(workloadId string, allocator vmAllocator) *NodeHostServicesProvider {
+	return &NodeHostServicesProvider{
+		workloadId: workloadId,
+		allocator:  allocator,
+	}
+}
+
+func (m *NodeHostServicesProvider) KvGet(bucket string, key string) (goja.ArrayBuffer, error) {
+	if key == "FAIL" {
+		return goja.ArrayBuffer{}, errors.New("FAILY FAIL")
+	}
+
+	result := fmt.Sprintf("%s.%s", bucket, key)
+	bytes := []byte(result)
+	return m.allocator.AllocateByteArray(m.workloadId, bytes), nil
+}
+
+func (m *NodeHostServicesProvider) KvSet(bucket string, key string, value goja.ArrayBuffer) error {
+	return nil
+}
+func (m *NodeHostServicesProvider) KvDelete(bucket string, key string) error {
+	return nil
+}
+
+func (m *NodeHostServicesProvider) KvKeys(bucket string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *NodeHostServicesProvider) MessagingPublish(subject string, payload goja.ArrayBuffer) error {
+	return nil
+}
+
+func (m *NodeHostServicesProvider) MessagingRequest(subject string, payload goja.ArrayBuffer) (goja.ArrayBuffer, error) {
+	return goja.ArrayBuffer{}, nil
+}
+
+func (m *NodeHostServicesProvider) ObjectGet(bucket string, objectName string) (goja.ArrayBuffer, error) {
+	return goja.ArrayBuffer{}, nil
+}
+
+func (m *NodeHostServicesProvider) ObjectPut(bucket string, objectName string, payload goja.ArrayBuffer) error {
+	return nil
+}

--- a/agents/javascript/script_runner.go
+++ b/agents/javascript/script_runner.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"errors"
+
+	"github.com/dop251/goja"
+)
+
+type ScriptRunner struct {
+	factory providerFactory
+	scripts map[string]*goja.Runtime
+}
+
+type hostServiceProvider interface {
+	KvGet(bucket string, key string) (goja.ArrayBuffer, error)
+	KvSet(bucket string, key string, value goja.ArrayBuffer) error
+	KvDelete(bucket string, key string) error
+	KvKeys(bucket string) ([]string, error)
+
+	MessagingPublish(subject string, payload goja.ArrayBuffer) error
+	MessagingRequest(subject string, payload goja.ArrayBuffer) (goja.ArrayBuffer, error)
+
+	ObjectGet(bucket string, objectName string) (goja.ArrayBuffer, error)
+	ObjectPut(bucket string, objectName string, data goja.ArrayBuffer) error
+}
+
+type providerFactory func(workloadId string, allocator vmAllocator) hostServiceProvider
+
+type vmAllocator interface {
+	AllocateByteArray(workloadId string, bytes []byte) goja.ArrayBuffer
+}
+
+func NewScriptRunner(factory providerFactory) *ScriptRunner {
+	return &ScriptRunner{
+		factory: factory,
+		scripts: make(map[string]*goja.Runtime),
+	}
+}
+
+func (r *ScriptRunner) AllocateByteArray(workloadId string, bytes []byte) goja.ArrayBuffer {
+	return r.GetVm(workloadId).NewArrayBuffer(bytes)
+}
+
+func (r *ScriptRunner) GetVm(workloadId string) *goja.Runtime {
+	return r.scripts[workloadId]
+}
+
+func (r *ScriptRunner) AddScript(workloadId string, script string) error {
+	vm := goja.New()
+	vm.SetFieldNameMapper(goja.UncapFieldNameMapper())
+	theProvider := r.factory(workloadId, r)
+	vm.Set("host", theProvider)
+	_, err := vm.RunString(script)
+	if err != nil {
+		return err
+	}
+	_, ok := goja.AssertFunction(vm.Get("run"))
+	if !ok {
+		return errors.New("no 'run' function in script")
+	}
+
+	r.scripts[workloadId] = vm
+
+	return nil
+}
+
+func (r *ScriptRunner) RemoveScript(workloadId string) error {
+
+	delete(r.scripts, workloadId)
+	// TODO: this _should_ garbage collect nicely, but at some point we'll
+	// want a test to make sure we don't leak when stopping
+
+	return nil
+}
+
+func (r *ScriptRunner) TriggerScript(workloadId string, input []byte) ([]byte, error) {
+	vm := r.scripts[workloadId]
+
+	runFunc, ok := goja.AssertFunction(vm.Get("run"))
+	if !ok {
+		return nil, errors.New("no 'run' function found")
+	}
+
+	res, err := runFunc(goja.Undefined())
+	if err != nil {
+		return nil, err
+	}
+	out, ok := res.Export().(goja.ArrayBuffer)
+	if !ok {
+		outBytes, err := res.ToObject(vm).MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		return outBytes, nil
+	}
+	return out.Bytes(), nil
+}

--- a/agents/javascript/script_runner_test.go
+++ b/agents/javascript/script_runner_test.go
@@ -1,0 +1,142 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/nats-io/nuid"
+)
+
+func setupSuite(t testing.TB) (*ScriptRunner, string, func(tb testing.TB)) {
+	// I love how this would make the Rust compiler send a hit squad after me
+	runner := NewScriptRunner(testProviderFactory)
+
+	return runner, nuid.Next(), func(tb testing.TB) {
+		// do cleanup
+	}
+}
+
+func TestRawObject(t *testing.T) {
+	runner, workloadId, teardown := setupSuite(t)
+	defer teardown(t)
+
+	err := runner.AddScript(workloadId,
+		`
+		function run() {
+		return { name: "John", age: 30 };
+	}
+
+		`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	res, err := runner.TriggerScript(workloadId, []byte{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	fmt.Printf("%s", string(res))
+}
+
+func TestKvGet(t *testing.T) {
+	runner, workloadId, teardown := setupSuite(t)
+	defer teardown(t)
+
+	err := runner.AddScript(workloadId,
+		`
+	function run() {
+		return host.kvGet("bucket", "key");
+        }
+`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	res, err := runner.TriggerScript(workloadId, []byte{})
+	fmt.Printf("%#v\n", res)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	fmt.Println(string(res))
+}
+
+func TestKvGetError(t *testing.T) {
+	runner, workloadId, teardown := setupSuite(t)
+	defer teardown(t)
+
+	err := runner.AddScript(workloadId,
+		`
+	function run() {
+		return host.kvGet("bucket", "FAIL");
+        }
+`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	_, err = runner.TriggerScript(workloadId, []byte{})
+	if err == nil {
+		t.Error(errors.New("Should have returned an error but didn't"))
+		return
+	}
+	fmt.Printf("%+v\n", err)
+
+}
+
+type mockHost struct {
+	workloadId string
+	allocator  vmAllocator
+}
+
+var _ hostServiceProvider = &mockHost{}
+
+func testProviderFactory(workloadId string, allocator vmAllocator) hostServiceProvider {
+	return &mockHost{
+		workloadId: workloadId,
+		allocator:  allocator,
+	}
+}
+
+func (m *mockHost) KvGet(bucket string, key string) (goja.ArrayBuffer, error) {
+	if key == "FAIL" {
+		return goja.ArrayBuffer{}, errors.New("FAILY FAIL")
+	}
+
+	result := fmt.Sprintf("%s.%s", bucket, key)
+	bytes := []byte(result)
+	return m.allocator.AllocateByteArray(m.workloadId, bytes), nil
+}
+
+func (m *mockHost) KvSet(bucket string, key string, value goja.ArrayBuffer) error {
+	return nil
+}
+func (m *mockHost) KvDelete(bucket string, key string) error {
+	return nil
+}
+
+func (m *mockHost) KvKeys(bucket string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mockHost) MessagingPublish(subject string, payload goja.ArrayBuffer) error {
+	return nil
+}
+
+func (m *mockHost) MessagingRequest(subject string, payload goja.ArrayBuffer) (goja.ArrayBuffer, error) {
+	return goja.ArrayBuffer{}, nil
+}
+
+func (m *mockHost) ObjectGet(bucket string, objectName string) (goja.ArrayBuffer, error) {
+	return goja.ArrayBuffer{}, nil
+}
+
+func (m *mockHost) ObjectPut(bucket string, objectName string, payload goja.ArrayBuffer) error {
+	return nil
+}


### PR DESCRIPTION
This sets up the ability to run javascript functions (must be named `run`) lambda-style with a host services provider. It does not yet complete the circle of life so scripts won't yet be executable front to back, but I think that will get buttoned up in the next PR. Wanted to keep this one focused on just the script execution.