### PR TITLE
fix: retry credential acquisition with exponential backoff

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -306,7 +306,7 @@ func (n *NexNode) handleAuctionDeployWorkload() func(micro.Request) {
 		// NATS permissions — specifically the log sub scope
 		// $NEX.FEED.<ns>.logs.> — must line up with where the workload
 		// actually lives, which is req.Namespace.
-		wlNatsConn, err := n.minter.Mint(models.WorkloadCred, req.Namespace, workloadID)
+		wlNatsConn, err := n.handlerMinter.Mint(models.WorkloadCred, req.Namespace, workloadID)
 		if err != nil {
 			n.handlerError(r, err, models.ErrCodeInternalServerError, "failed to mint workload nats connection")
 			return
@@ -596,7 +596,7 @@ func (n *NexNode) handleRegisterAgent() func(micro.Request) {
 			return
 		}
 
-		natsConn, err := n.minter.Mint(models.AgentCred, "", agentID)
+		natsConn, err := n.handlerMinter.Mint(models.AgentCred, "", agentID)
 		if err != nil {
 			n.handlerError(r, err, models.ErrCodeInternalServerError, "failed to mint nats connection")
 			return
@@ -609,9 +609,11 @@ func (n *NexNode) handleRegisterAgent() func(micro.Request) {
 
 		state := models.RegisterAgentResponseExistingState{}
 		for workloadID, swr := range agentState {
-			natsConn, err := n.minter.Mint(models.WorkloadCred, swr.Namespace, workloadID)
+			natsConn, err := n.handlerMinter.Mint(models.WorkloadCred, swr.Namespace, workloadID)
 			if err != nil {
-				n.logger.Warn("failed to mint workload nats connection", slog.String("err", err.Error()), slog.String("namespace", swr.Namespace), slog.String("workload_id", workloadID))
+				// Workload is dropped from the agent's resume state — surface it
+				// as an error, not just a warning.
+				n.logger.Error("failed to mint workload nats connection, workload dropped from resume state", slog.String("err", err.Error()), slog.String("namespace", swr.Namespace), slog.String("workload_id", workloadID))
 				continue
 			}
 			aswr := models.AgentStartWorkloadRequest{
@@ -657,7 +659,7 @@ func (n *NexNode) handleRegisterRemoteAgent() func(micro.Request) {
 			return
 		}
 
-		connData, err := n.minter.MintRegister(agentID, pubNodeKey)
+		connData, err := n.handlerMinter.MintRegister(agentID, pubNodeKey)
 		if err != nil {
 			n.handlerError(r, err, models.ErrCodeInternalServerError, "failed to mint register")
 			return

--- a/internal/credentials/retrying.go
+++ b/internal/credentials/retrying.go
@@ -1,0 +1,36 @@
+package credentials
+
+import (
+	"context"
+
+	"github.com/synadia-io/nex/internal/retry"
+	"github.com/synadia-io/nex/models"
+)
+
+// WithRetry wraps vendor so every mint is retried per policy. A transient
+// vendor failure (e.g. a control-plane-backed minter hiccuping) must not
+// permanently skip an agent or fail a request that would succeed moments
+// later.
+func WithRetry(ctx context.Context, vendor models.CredVendor, policy retry.Policy) models.CredVendor {
+	return &retryingVendor{ctx: ctx, inner: vendor, policy: policy}
+}
+
+type retryingVendor struct {
+	// ctx bounds retries to the owning node's lifetime; the CredVendor
+	// methods take no context of their own.
+	ctx    context.Context
+	inner  models.CredVendor
+	policy retry.Policy
+}
+
+func (v *retryingVendor) MintRegister(agentId, nodeId string) (*models.NatsConnectionData, error) {
+	return retry.Do(v.ctx, v.policy, func() (*models.NatsConnectionData, error) {
+		return v.inner.MintRegister(agentId, nodeId)
+	})
+}
+
+func (v *retryingVendor) Mint(typ models.CredType, namespace, id string) (*models.NatsConnectionData, error) {
+	return retry.Do(v.ctx, v.policy, func() (*models.NatsConnectionData, error) {
+		return v.inner.Mint(typ, namespace, id)
+	})
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,93 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+)
+
+// Policy bundles retry tuning so call sites reference a named intent instead
+// of repeating positional constants.
+type Policy struct {
+	Attempts int
+	Base     time.Duration
+	MaxDelay time.Duration
+}
+
+var (
+	// Long suits startup paths that should ride out a real outage.
+	Long = Policy{Attempts: 5, Base: 250 * time.Millisecond, MaxDelay: 5 * time.Second}
+	// Short suits request handlers that must answer within the caller's
+	// request timeout.
+	Short = Policy{Attempts: 3, Base: 100 * time.Millisecond, MaxDelay: time.Second}
+)
+
+// Permanent marks err as non-retryable: Do stops immediately and returns the
+// original err unwrapped. Use it for failures that resending cannot heal,
+// e.g. a request that is not idempotent once the server has processed it.
+func Permanent(err error) error {
+	return &permanentError{err}
+}
+
+type permanentError struct{ err error }
+
+func (p *permanentError) Error() string { return p.err.Error() }
+func (p *permanentError) Unwrap() error { return p.err }
+
+// Jitter returns a duration drawn uniformly from [d/2, d] so
+// simultaneously-started retriers (e.g. many agents registering at once) do
+// not stampede in lockstep.
+func Jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return d/2 + rand.N(d/2+1)
+}
+
+// Do calls fn up to p.Attempts times, sleeping between failed attempts with
+// jittered exponential backoff starting at p.Base and capped at p.MaxDelay.
+// It aborts early when ctx is done (returning the last error from fn joined
+// with the context error) or when fn returns an error marked Permanent.
+func Do[T any](ctx context.Context, p Policy, fn func() (T, error)) (T, error) {
+	var zero T
+	attempts := max(p.Attempts, 1)
+	delay := max(p.Base, time.Millisecond)
+	maxDelay := max(p.MaxDelay, delay)
+
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			return zero, errors.Join(lastErr, err)
+		}
+
+		ret, err := fn()
+		if err == nil {
+			return ret, nil
+		}
+		var pe *permanentError
+		if errors.As(err, &pe) {
+			return zero, pe.err
+		}
+		lastErr = err
+
+		if i == attempts-1 {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return zero, errors.Join(lastErr, ctx.Err())
+		case <-time.After(Jitter(delay)):
+		}
+
+		if delay > maxDelay/2 { // overflow-safe doubling
+			delay = maxDelay
+		} else {
+			delay *= 2
+		}
+	}
+
+	return zero, fmt.Errorf("failed after %d attempts: %w", attempts, lastErr)
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,142 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDoSucceedsFirstAttempt(t *testing.T) {
+	calls := 0
+	got, err := Do(context.Background(), Policy{Attempts: 5, Base: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() (int, error) {
+		calls++
+		return 42, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 42 || calls != 1 {
+		t.Fatalf("got=%d calls=%d, want got=42 calls=1", got, calls)
+	}
+}
+
+func TestDoSucceedsAfterFailures(t *testing.T) {
+	calls := 0
+	got, err := Do(context.Background(), Policy{Attempts: 5, Base: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() (string, error) {
+		calls++
+		if calls < 3 {
+			return "", errors.New("transient")
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "ok" || calls != 3 {
+		t.Fatalf("got=%q calls=%d, want got=\"ok\" calls=3", got, calls)
+	}
+}
+
+func TestDoExhaustsAttempts(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("always fails")
+	_, err := Do(context.Background(), Policy{Attempts: 3, Base: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() (int, error) {
+		calls++
+		return 0, sentinel
+	})
+	if calls != 3 {
+		t.Fatalf("calls=%d, want 3", calls)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v, want wrapped sentinel", err)
+	}
+}
+
+func TestDoZeroAttemptsCoercedToOne(t *testing.T) {
+	calls := 0
+	_, err := Do(context.Background(), Policy{Attempts: 0, Base: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() (int, error) {
+		calls++
+		return 0, errors.New("nope")
+	})
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1", calls)
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDoHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	sentinel := errors.New("transient")
+	_, err := Do(ctx, Policy{Attempts: 100, Base: time.Hour, MaxDelay: time.Hour}, func() (int, error) {
+		calls++
+		cancel()
+		return 0, sentinel
+	})
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1 (cancel should stop retries during sleep)", calls)
+	}
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v, want joined context.Canceled + sentinel", err)
+	}
+}
+
+func TestDoAlreadyCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	_, err := Do(ctx, Policy{Attempts: 5, Base: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() (int, error) {
+		calls++
+		return 0, errors.New("nope")
+	})
+	if calls != 0 {
+		t.Fatalf("calls=%d, want 0", calls)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context.Canceled", err)
+	}
+}
+
+func TestDoBacksOffBetweenAttempts(t *testing.T) {
+	start := time.Now()
+	_, _ = Do(context.Background(), Policy{Attempts: 3, Base: 20 * time.Millisecond, MaxDelay: 100 * time.Millisecond}, func() (int, error) {
+		return 0, errors.New("nope")
+	})
+	// Two sleeps: jittered [10,20]ms + [20,40]ms => at least 30ms total.
+	if elapsed := time.Since(start); elapsed < 30*time.Millisecond {
+		t.Fatalf("elapsed=%v, want >=30ms of backoff", elapsed)
+	}
+}
+
+func TestDoPermanentStopsRetry(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("not idempotent")
+	_, err := Do(context.Background(), Policy{Attempts: 5, Base: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() (int, error) {
+		calls++
+		return 0, Permanent(sentinel)
+	})
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1 (Permanent must stop retries)", calls)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v, want the original sentinel", err)
+	}
+	if got := err.Error(); got != sentinel.Error() {
+		t.Fatalf("err=%q, want unwrapped original %q", got, sentinel.Error())
+	}
+}
+
+func TestJitterBounds(t *testing.T) {
+	if got := Jitter(0); got != 0 {
+		t.Fatalf("Jitter(0)=%v, want 0", got)
+	}
+	for range 100 {
+		d := Jitter(time.Second)
+		if d < 500*time.Millisecond || d > time.Second {
+			t.Fatalf("Jitter(1s)=%v, want within [500ms, 1s]", d)
+		}
+	}
+}

--- a/internal/watcher.go
+++ b/internal/watcher.go
@@ -9,12 +9,14 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
-	"github.com/synadia-io/nex/sdk/go/agent"
+	"github.com/synadia-io/nex/internal/retry"
 	"github.com/synadia-io/nex/models"
+	"github.com/synadia-io/nex/sdk/go/agent"
 )
 
 type AgentProcess struct {
@@ -48,7 +50,8 @@ type AgentWatcher struct {
 	localAgents    map[string]*AgentProcess // maps agentID to AgentProcess
 	localAgentLock sync.Mutex               // Lock for managing access to localAgents
 
-	agentCount int
+	// mutated from concurrent per-agent goroutines
+	agentCount atomic.Int32
 }
 
 func NewAgentWatcher(ctx context.Context, nc *nats.Conn, kp nkeys.KeyPair, logger *slog.Logger, emitter models.EventEmitter, restarts int, wg *sync.WaitGroup) *AgentWatcher {
@@ -60,7 +63,6 @@ func NewAgentWatcher(ctx context.Context, nc *nats.Conn, kp nkeys.KeyPair, logge
 		emitter:      emitter,
 		resetLimit:   restarts,
 		initAgentsWg: wg,
-		agentCount:   0,
 
 		embeddedAgents:     make(map[string]*agent.Runner),
 		embeddedAgentsLock: sync.Mutex{},
@@ -76,7 +78,7 @@ func (a *AgentWatcher) WaitForAgents() {
 }
 
 func (a *AgentWatcher) Shutdown() {
-	a.logger.Info("shutting down agent watcher", slog.Int("agent_count", a.agentCount))
+	a.logger.Info("shutting down agent watcher", slog.Int("agent_count", int(a.agentCount.Load())))
 
 	// Stop all embedded agents
 	for agentID := range a.embeddedAgents {
@@ -99,32 +101,59 @@ func (a *AgentWatcher) Shutdown() {
 	a.logger.Info("agent watcher shutdown complete")
 }
 
-func (a *AgentWatcher) StartEmbeddedAgent(agentID string, runner *agent.Runner, connData *models.NatsConnectionData) {
-	restartCount := 0
+// Restart attempts back off exponentially so a transient outage (e.g. NATS
+// briefly unavailable during agent registration) does not consume every
+// allowed restart within milliseconds and give up permanently.
+const (
+	restartBackoffBase = time.Second
+	restartBackoffMax  = 30 * time.Second
+)
 
-	for range a.resetLimit {
-		a.logger.Debug("starting embedded agent", slog.String("agent_id", agentID), slog.Int("restart_count", restartCount))
-		err := runner.Run(agentID, *connData, a.emitter)
-		if err != nil {
-			restartCount++
-			if restartCount <= a.resetLimit {
-				a.logger.Warn("restarting agent", slog.String("agent_name", runner.String()), slog.Int("restart_count", restartCount), slog.Int("reset_limit", a.resetLimit), slog.String("err", err.Error()))
-				continue
-			} else {
-				a.logger.Error("agent failed to start after maximum retries", slog.String("agent_name", runner.String()), slog.Int("reset_limit", a.resetLimit), slog.String("err", err.Error()))
-				a.initAgentsWg.Done()
-				return
-			}
-		}
-		break
+// restartBackoffDelay returns the sleep before restart attempt n (1-based):
+// base doubled per attempt, capped at restartBackoffMax. The shift is clamped
+// so large n cannot wrap the duration negative.
+func restartBackoffDelay(n int) time.Duration {
+	return min(restartBackoffBase<<min(n-1, 5), restartBackoffMax)
+}
+
+// backoffBeforeRestart sleeps with jittered exponential backoff before
+// restart attempt n (1-based). It returns false if the watcher context ended
+// while waiting.
+func (a *AgentWatcher) backoffBeforeRestart(n int) bool {
+	select {
+	case <-a.ctx.Done():
+		return false
+	case <-time.After(retry.Jitter(restartBackoffDelay(n))):
+		return true
 	}
+}
 
-	a.embeddedAgentsLock.Lock()
-	a.embeddedAgents[agentID] = runner
-	a.embeddedAgentsLock.Unlock()
+func (a *AgentWatcher) StartEmbeddedAgent(agentID string, runner *agent.Runner, connData *models.NatsConnectionData) {
+	defer a.initAgentsWg.Done()
 
-	a.agentCount++
-	a.initAgentsWg.Done()
+	attempts := max(a.resetLimit, 1)
+	for attempt := 1; attempt <= attempts; attempt++ {
+		a.logger.Debug("starting embedded agent", slog.String("agent_id", agentID), slog.Int("attempt", attempt))
+		err := runner.Run(agentID, *connData, a.emitter)
+		if err == nil {
+			a.embeddedAgentsLock.Lock()
+			a.embeddedAgents[agentID] = runner
+			a.embeddedAgentsLock.Unlock()
+
+			a.agentCount.Add(1)
+			return
+		}
+
+		if attempt == attempts {
+			a.logger.Error("agent failed to start after maximum retries", slog.String("agent_name", runner.String()), slog.Int("reset_limit", a.resetLimit), slog.String("err", err.Error()))
+			return
+		}
+
+		a.logger.Warn("restarting agent", slog.String("agent_name", runner.String()), slog.Int("attempt", attempt), slog.Int("reset_limit", a.resetLimit), slog.String("err", err.Error()))
+		if !a.backoffBeforeRestart(attempt) {
+			return
+		}
+	}
 }
 
 func (a *AgentWatcher) StopEmbeddedAgent(agentID string) error {
@@ -144,7 +173,7 @@ func (a *AgentWatcher) StopEmbeddedAgent(agentID string) error {
 	}
 
 	a.logger.Debug("stopped embedded agent", slog.String("agent_id", agentID))
-	a.agentCount--
+	a.agentCount.Add(-1)
 
 	pubKey, err := a.nodeKeypair.PublicKey()
 	if err != nil {
@@ -180,6 +209,13 @@ func (a *AgentWatcher) StartLocalBinaryAgent(ap *AgentProcess, regCreds *models.
 			}
 			return
 		default:
+			if ap.restartCount > 0 && !a.backoffBeforeRestart(ap.restartCount) {
+				if !ap.initialized {
+					a.initAgentsWg.Done()
+				}
+				return
+			}
+
 			ap.agentLock.Lock()
 
 			env := []string{}
@@ -220,7 +256,7 @@ func (a *AgentWatcher) StartLocalBinaryAgent(ap *AgentProcess, regCreds *models.
 				a.initAgentsWg.Done()
 			}
 			ap.initialized = true
-			a.agentCount++
+			a.agentCount.Add(1)
 
 			a.localAgentLock.Lock()
 			a.localAgents[ap.ID] = ap
@@ -235,7 +271,7 @@ func (a *AgentWatcher) StartLocalBinaryAgent(ap *AgentProcess, regCreds *models.
 				a.logger.Warn("Nexlet process unexpectedly exited with state", slog.Any("state", cmd.ProcessState), slog.Int("process", ap.Process.Pid))
 			}
 
-			a.agentCount--
+			a.agentCount.Add(-1)
 
 			if ap.state == models.AgentStateStopping || ap.state == models.AgentStateLameduck {
 				break
@@ -243,6 +279,12 @@ func (a *AgentWatcher) StartLocalBinaryAgent(ap *AgentProcess, regCreds *models.
 
 			ap.restartCount++
 		}
+	}
+
+	// Loop exhausted without a single successful start: release the startup
+	// gate so WaitForAgents does not block forever.
+	if !ap.initialized {
+		a.initAgentsWg.Done()
 	}
 }
 

--- a/internal/watcher_backoff_test.go
+++ b/internal/watcher_backoff_test.go
@@ -1,0 +1,44 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/carlmjohnson/be"
+)
+
+func TestBackoffBeforeRestartDelayGrowsAndCaps(t *testing.T) {
+	tt := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{6, restartBackoffMax},
+		{100, restartBackoffMax}, // must not overflow the shift
+	}
+	for _, tc := range tt {
+		be.Equal(t, tc.want, restartBackoffDelay(tc.attempt))
+	}
+}
+
+func TestBackoffBeforeRestartHonorsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &AgentWatcher{ctx: ctx}
+
+	cancel()
+	start := time.Now()
+	be.False(t, w.backoffBeforeRestart(6)) // would otherwise sleep 30s
+	be.True(t, time.Since(start) < time.Second)
+}
+
+func TestBackoffBeforeRestartSleeps(t *testing.T) {
+	w := &AgentWatcher{ctx: context.Background()}
+
+	start := time.Now()
+	be.True(t, w.backoffBeforeRestart(1))
+	// Sleep is jittered within [delay/2, delay].
+	be.True(t, time.Since(start) >= restartBackoffBase/2)
+}

--- a/mint_retry_test.go
+++ b/mint_retry_test.go
@@ -1,0 +1,112 @@
+package nex
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/carlmjohnson/be"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nkeys"
+	tminter "github.com/synadia-io/nex/_test/minter"
+	inmem "github.com/synadia-io/nex/_test/nexlet_inmem"
+	"github.com/synadia-io/nex/models"
+)
+
+// flakyMinter fails the first failures calls of each method before delegating
+// to the wrapped minter, simulating a transient control-plane outage.
+type flakyMinter struct {
+	inner    models.CredVendor
+	failures int
+
+	mu            sync.Mutex
+	registerCalls int
+	mintCalls     int
+}
+
+func (m *flakyMinter) MintRegister(agentId, nodeId string) (*models.NatsConnectionData, error) {
+	m.mu.Lock()
+	m.registerCalls++
+	fail := m.registerCalls <= m.failures
+	m.mu.Unlock()
+	if fail {
+		return nil, errors.New("transient minter failure")
+	}
+	return m.inner.MintRegister(agentId, nodeId)
+}
+
+func (m *flakyMinter) Mint(typ models.CredType, namespace, id string) (*models.NatsConnectionData, error) {
+	m.mu.Lock()
+	m.mintCalls++
+	fail := m.mintCalls <= m.failures
+	m.mu.Unlock()
+	if fail {
+		return nil, errors.New("transient minter failure")
+	}
+	return m.inner.Mint(typ, namespace, id)
+}
+
+// TestNodeStartSurvivesTransientMintFailures proves that a minter which fails
+// its first attempts (e.g. a control-plane-backed vendor hiccuping) no longer
+// permanently skips agent startup: both the node-side MintRegister and the
+// registration handler's Mint are retried with backoff.
+func TestNodeStartSurvivesTransientMintFailures(t *testing.T) {
+	s := startNatsServer(t)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL())
+	be.NilErr(t, err)
+	defer nc.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	kp, err := nkeys.CreateServer()
+	be.NilErr(t, err)
+
+	pub, err := kp.PublicKey()
+	be.NilErr(t, err)
+
+	r, err := inmem.NewInMemAgent("nexus", pub, logger)
+	be.NilErr(t, err)
+
+	minter := &flakyMinter{
+		inner:    &tminter.TestMinter{NatsServers: []string{s.ClientURL()}},
+		failures: 2,
+	}
+
+	nn, err := NewNexNode(
+		WithNatsConn(nc),
+		WithLogger(logger),
+		WithNodeKeyPair(kp),
+		WithAgentRunner(r),
+		WithMinter(minter),
+	)
+	be.NilErr(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		be.NilErr(t, nn.Shutdown())
+	}()
+
+	be.NilErr(t, nn.Start())
+	be.NilErr(t, nn.IsReady(10*time.Second))
+
+	be.Equal(t, 1, nn.registeredAgents.Count())
+
+	minter.mu.Lock()
+	registerCalls, mintCalls := minter.registerCalls, minter.mintCalls
+	minter.mu.Unlock()
+	// Both methods must have been retried past their injected failures.
+	be.True(t, registerCalls > minter.failures)
+	be.True(t, mintCalls > minter.failures)
+
+	cancel()
+	be.NilErr(t, nn.WaitForShutdown())
+}

--- a/node.go
+++ b/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/synadia-io/nex/internal/credentials"
 	eventemitter "github.com/synadia-io/nex/internal/event_emitter"
 	"github.com/synadia-io/nex/internal/idgen"
+	"github.com/synadia-io/nex/internal/retry"
 	secretstore "github.com/synadia-io/nex/internal/secret_store"
 	"github.com/synadia-io/nex/internal/state"
 	"github.com/synadia-io/nex/models"
@@ -70,7 +71,13 @@ type (
 		// List of active agents
 		registeredAgents *internal.AgentRegistrations
 
-		minter       models.CredVendor
+		minter models.CredVendor
+		// minter wrapped with retry policies: startup rides out longer
+		// outages, handlers must answer within the caller's request timeout.
+		startupMinter models.CredVendor
+		handlerMinter models.CredVendor
+
+		agentStarter *sync.WaitGroup
 		state        models.NexNodeState
 		auctioneer   models.Auctioneer
 		idgen        models.IDGen
@@ -178,9 +185,14 @@ func NewNexNode(opts ...NexNodeOption) (*NexNode, error) {
 	}
 	n.registeredAgents = internal.NewAgentRegistrations(n.ctx, pubKey, n.nc, n.logger.WithGroup("agent-registrations"))
 
-	var agentStarter sync.WaitGroup
-	agentStarter.Add(len(n.embeddedRunners) + len(n.localRunners))
-	n.agentWatcher = internal.NewAgentWatcher(n.ctx, n.nc, n.nodeKeypair, n.logger.WithGroup("agent-watcher"), n.eventEmitter, n.agentRestartLimit, &agentStarter)
+	n.startupMinter = credentials.WithRetry(n.ctx, n.minter, retry.Long)
+	n.handlerMinter = credentials.WithRetry(n.ctx, n.minter, retry.Short)
+
+	// One token per agent goroutine, added right before each launch in
+	// Start(); a bulk Add here would leak tokens (and deadlock
+	// WaitForAgents) for agents whose mint fails and never launch.
+	n.agentStarter = new(sync.WaitGroup)
+	n.agentWatcher = internal.NewAgentWatcher(n.ctx, n.nc, n.nodeKeypair, n.logger.WithGroup("agent-watcher"), n.eventEmitter, n.agentRestartLimit, n.agentStarter)
 
 	return n, nil
 }
@@ -313,11 +325,12 @@ func (n *NexNode) Start() error {
 	// Start agents via constructor
 	for _, runner := range n.embeddedRunners {
 		id := n.idgen.Generate(nil)
-		connData, err := n.minter.MintRegister(id, n.id)
+		connData, err := n.startupMinter.MintRegister(id, n.id)
 		if err != nil {
 			n.logger.Error("failed to mint register", slog.String("err", err.Error()))
 			continue
 		}
+		n.agentStarter.Add(1)
 		go n.agentWatcher.StartEmbeddedAgent(id, runner, connData)
 	}
 
@@ -325,11 +338,12 @@ func (n *NexNode) Start() error {
 	for _, agentProcess := range n.localRunners {
 		agentProcess.HostNode = n.id
 		agentProcess.ID = n.idgen.Generate(nil)
-		connData, err := n.minter.MintRegister(agentProcess.ID, n.id)
+		connData, err := n.startupMinter.MintRegister(agentProcess.ID, n.id)
 		if err != nil {
 			n.logger.Error("failed to mint register", slog.String("err", err.Error()))
 			continue
 		}
+		n.agentStarter.Add(1)
 		go n.agentWatcher.StartLocalBinaryAgent(agentProcess, connData)
 	}
 

--- a/sdk/go/agent/register_retry_test.go
+++ b/sdk/go/agent/register_retry_test.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/carlmjohnson/be"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/nex/models"
+)
+
+// TestRemoteAgentInitRetriesUntilNodeResponds proves the registration request
+// is retried with backoff: the node's responder only appears after the first
+// attempt would already have failed with ErrNoResponders. Before the retry
+// change, RemoteAgentInit failed instantly in this scenario.
+func TestRemoteAgentInitRetriesUntilNodeResponds(t *testing.T) {
+	s := server.New(&server.Options{Port: -1})
+	s.Start()
+	defer s.Shutdown()
+	if !s.ReadyForConnections(5 * time.Second) {
+		t.Fatal("nats server failed to start")
+	}
+
+	nc, err := nats.Connect(s.ClientURL())
+	be.NilErr(t, err)
+	defer nc.Close()
+
+	const nexus = "retry-test-nexus"
+
+	// First attempt fails fast (no responders). Bring the responder up while
+	// the retry loop is backing off.
+	go func() {
+		time.Sleep(400 * time.Millisecond)
+
+		snc, err := nats.Connect(s.ClientURL())
+		if err != nil {
+			return
+		}
+
+		_, err = snc.Subscribe(models.AgentAPIInitRemoteRegisterRequestSubject(nexus), func(m *nats.Msg) {
+			resp, _ := json.Marshal(models.RegisterRemoteAgentResponse{
+				AssignedAgentId: "agent-123",
+				RespondTo:       "node-abc",
+			})
+			_ = m.Respond(resp)
+		})
+		if err != nil {
+			return
+		}
+		_ = snc.Flush()
+	}()
+
+	resp, err := RemoteAgentInit(nc, nexus, "unused")
+	be.NilErr(t, err)
+	be.Equal(t, "agent-123", resp.AssignedAgentId)
+}

--- a/sdk/go/agent/runner.go
+++ b/sdk/go/agent/runner.go
@@ -9,9 +9,11 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/synadia-io/nex/internal/retry"
 	"github.com/synadia-io/nex/models"
 
 	"github.com/nats-io/nats.go"
@@ -21,6 +23,22 @@ import (
 const (
 	EnvVarPrefix = "NEX_AGENT"
 )
+
+// requestWithRetry sends req and retries with backoff ONLY while the node is
+// not subscribed yet (nats.ErrNoResponders — instant, safe to resend), so a
+// blip during node restart does not kill the agent before it ever receives
+// its credentials. Any other failure — including a timeout — is permanent:
+// the node may already have processed the request, and registration is not
+// idempotent, so resending it would trip "already registered".
+func requestWithRetry(ctx context.Context, nc *nats.Conn, subject string, data []byte, timeout time.Duration) (*nats.Msg, error) {
+	return retry.Do(ctx, retry.Long, func() (*nats.Msg, error) {
+		msg, err := nc.Request(subject, data, timeout)
+		if err != nil && !errors.Is(err, nats.ErrNoResponders) {
+			return nil, retry.Permanent(err)
+		}
+		return msg, err
+	})
+}
 
 var (
 	defaultEmitEvent func(string, any) error = func(string, any) error { return nil }
@@ -44,6 +62,8 @@ type Runner struct {
 	agent Agent
 	nc    *nats.Conn
 	micro micro.Service
+
+	metricsOnce sync.Once
 
 	secretStore models.SecretStore
 
@@ -104,7 +124,7 @@ func RemoteAgentInit(nc *nats.Conn, nexus, pubKey string) (*models.RegisterRemot
 		return nil, fmt.Errorf("failed to marshal remote agent registration request: %w", err)
 	}
 
-	regResp, err := nc.Request(models.AgentAPIInitRemoteRegisterRequestSubject(nexus), reqB, time.Second*3)
+	regResp, err := requestWithRetry(context.Background(), nc, models.AgentAPIInitRemoteRegisterRequestSubject(nexus), reqB, time.Second*3)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send remote agent registration request: %w", err)
 	}
@@ -169,13 +189,17 @@ func (a *Runner) Run(agentID string, connData models.NatsConnectionData, eventEm
 	a.EmitEvent = eventEmitter.EmitEvent
 
 	if a.metrics {
-		go func() {
-			http.Handle("/metrics", promhttp.Handler())
-			err := http.ListenAndServe(fmt.Sprintf(":%d", a.metricsPort), nil)
-			if err != nil {
-				a.logger.Error("failed to start metrics server", slog.String("err", err.Error()), slog.String("agent_id", agentID))
-			}
-		}()
+		// Run is re-invoked by the watcher on failure; registering /metrics
+		// twice on the default mux would panic and take the process down.
+		a.metricsOnce.Do(func() {
+			go func() {
+				http.Handle("/metrics", promhttp.Handler())
+				err := http.ListenAndServe(fmt.Sprintf(":%d", a.metricsPort), nil)
+				if err != nil {
+					a.logger.Error("failed to start metrics server", slog.String("err", err.Error()), slog.String("agent_id", agentID))
+				}
+			}()
+		})
 	}
 
 	var err error
@@ -201,9 +225,7 @@ func (a *Runner) Run(agentID string, connData models.NatsConnectionData, eventEm
 		return fmt.Errorf("failed to marshal registration request: %w", err)
 	}
 
-	var regRet *nats.Msg
-
-	regRet, err = a.nc.Request(models.AgentAPIRegisterRequestSubject(agentID, a.nodeID), registerB, time.Minute)
+	regRet, err := requestWithRetry(a.ctx, a.nc, models.AgentAPIRegisterRequestSubject(agentID, a.nodeID), registerB, time.Minute)
 	if err != nil {
 		return fmt.Errorf("failed to send agent registration request to node %s: %w", a.nodeID, err)
 	}


### PR DESCRIPTION
## Problem

Every credential-acquisition path in nex was one-shot — zero retries, zero backoff:

| Path | Location | On failure |
|------|----------|-----------|
| Node startup mint for embedded/local agents | `node.go` | log + skip — agent silently never starts |
| Handler mints (start-workload, agent registration, resume state, remote registration) | `handlers.go` (4 sites) | request fails; resume-state workloads silently dropped |
| Agent SDK `RemoteAgentInit` | `sdk/go/agent/runner.go` | single 3s request, error bubbles up |
| Agent SDK `Run` registration (where the nexlet receives its creds) | `sdk/go/agent/runner.go` | single request → process exits |
| AgentWatcher restarts (the only existing "retry") | `internal/watcher.go` | up to 3 restarts with **zero delay** — all burn inside the same transient blip, then gives up permanently |

A transient outage (NATS briefly unavailable, node restarting, control-plane-backed minter hiccup) at the wrong moment permanently killed agent startup or dropped workloads.

## Changes

- **`internal/retry` (new):** generic ctx-aware `retry.Do` with exponential backoff + jitter. Lives in its own subpackage because `internal` imports `sdk/go/agent` (import cycle otherwise).
- **Node mints** (`node.go`, `handlers.go`): all 6 sites wrapped. Handler-side retries are short (3 attempts, 100ms→1s) to fit inside the caller's request timeout; startup mints get 5 attempts, 250ms→5s. Resume-state mint failure now logs at Error (workload is dropped) instead of Warn.
- **Agent SDK registration** (`runner.go`): both requests retried (5 attempts, 250ms→5s). Only transport errors retry — an explicit `Success=false` rejection does not.
- **AgentWatcher backoff** (`watcher.go`): 1s doubling to a 30s cap between restart attempts, ctx-aware.
- **Bug fix:** the embedded-agent loop registered the agent as running even when every restart attempt failed — the `restartCount > resetLimit` branch was unreachable inside `for range a.resetLimit`. Failed agents are no longer added to `embeddedAgents`.

## Testing

- `internal/retry` table tests (success paths, exhaustion, ctx cancellation, backoff timing)
- `TestNodeStartSurvivesTransientMintFailures`: node + inmem agent with a minter that fails its first 2 calls of each method — agent still registers, both methods proven retried
- `TestRemoteAgentInitRetriesUntilNodeResponds`: responder appears 400ms after first attempt would have failed with ErrNoResponders — previously failed instantly
- Watcher backoff delay/cancellation tests
- Full `go test ./...` green, including the creds-rotation e2e suite

Stacked on #521 (`hotfix-010-cred-refresh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)